### PR TITLE
Refactor API gherkin files, RestHelper and User tests

### DIFF
--- a/1.Core/Helpers/APIRestHelper.cs
+++ b/1.Core/Helpers/APIRestHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json;
 using RestSharp;
 using RestSharp.Authenticators;
+using Todoly.Views.Models;
 
 namespace Todoly.Core.Helpers;
 public class RestHelper
@@ -19,54 +20,16 @@ public class RestHelper
     {
         client.Authenticator = new HttpBasicAuthenticator(username, password);
     }
-    public RestResponse Get(string url)
+
+    public RestResponse DoRequest(Method method, string endpoint, string? body)
     {
-        RestRequest request = new RestRequest(url, Method.Get);
-        RestResponse res = client.Execute(request);
-        return res!;
-    }
+        RestRequest request = new RestRequest(endpoint, method);
+        if (body != null)
+        {
+            request.AddParameter("application/json", body, ParameterType.RequestBody);
+        }
 
-    public RestResponse Post(string url, string body)
-    {
-        RestRequest request = new RestRequest(url, Method.Post);
-
-        request.AddParameter("application/json", body, ParameterType.RequestBody);
-
-        RestResponse res = client.Execute(request);
-        return res;
-    }
-
-    public RestResponse Post<T>(string url, T body)
-    {
-        RestRequest request = new RestRequest(url, Method.Post);
-
-        string bodyString = JsonSerializer.Serialize<T>(body);
-        request.AddParameter("application/json", bodyString, ParameterType.RequestBody);
-
-        RestResponse res = client.Execute(request);
-        return res;
-    }
-
-    public RestResponse Delete(string url)
-    {
-        RestRequest request = new RestRequest(url, Method.Delete);
-        RestResponse res = client.Execute(request);
-        return res!;
-    }
-
-    public RestResponse Put<T>(string url, T body)
-    {
-        RestRequest request = new RestRequest(url, Method.Put);
-
-        string bodyString = JsonSerializer.Serialize<T>(body);
-        request.AddParameter("application/json", bodyString, ParameterType.RequestBody);
-
-        RestResponse res = client.Execute(request);
-        return res;
-    }
-
-    public void Authenticate(string username, string password)
-    {
-        client.Authenticator = new HttpBasicAuthenticator(username, password);
+        RestResponse response = client.Execute(request);
+        return response;
     }
 }

--- a/1.Core/Helpers/Helpers.csproj
+++ b/1.Core/Helpers/Helpers.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="DotNetEnv" Version="2.4.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\2.Views\Models\Models.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/2.Views/Models/ErrorModel.cs
+++ b/2.Views/Models/ErrorModel.cs
@@ -1,11 +1,11 @@
 ﻿namespace Todoly.Views.Models;
 
-public record ErrorResponseModel
+public record ErrorModel
 {
     public string ErrorMessage { get; set; }
     public int ErrorCode { get; set; }
 
-    public ErrorResponseModel(string errorMessage, int errorCode)
+    public ErrorModel(string errorMessage, int errorCode)
     {
         ErrorMessage = errorMessage;
         ErrorCode = errorCode;

--- a/2.Views/Models/ItemModel.cs
+++ b/2.Views/Models/ItemModel.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Generic;
 
-public record ItemsPayload
+public record ItemModel
 {
     public long? Id { get; set; } = null;
     public string? Content { get; set; } = null;
@@ -20,7 +20,7 @@ public record ItemsPayload
     public int? ItemOrder { get; set; } = null;
     public int? Priority { get; set; } = null;
     public string? LastSyncedDateTime { get; set; } = null;
-    public List<ItemsPayload>? Children { get; set; } = null;
+    public List<ItemModel>? Children { get; set; } = null;
     public string? DueDateTime { get; set; } = null;
     public string? CreatedDate { get; set; } = null;
     public string? LastCheckedDate { get; set; } = null;
@@ -32,7 +32,7 @@ public record ItemsPayload
     public bool? DueTimeSpecified { get; set; } = null;
     public long? OwnerId { get; set; } = null;
 
-    public ItemsPayload(
+    public ItemModel(
         long? id,
         string? content,
         long? itemType,
@@ -48,7 +48,7 @@ public record ItemsPayload
         int? itemOrder,
         int? priority,
         string? lastSyncedDateTime,
-        List<ItemsPayload>? children,
+        List<ItemModel>? children,
         string? dueDateTime,
         string? createdDate,
         string? lastCheckedDate,

--- a/2.Views/Models/ProjectModel.cs
+++ b/2.Views/Models/ProjectModel.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Generic;
 
-public record ProjectPayload
+public record ProjectModel
 {
     public int? Id { get; set; }
     public string? Content { get; set; }
@@ -13,7 +13,7 @@ public record ProjectPayload
     public int? ParentId { get; set; }
     public bool? Collapsed { get; set; }
     public int? ItemOrder { get; set; }
-    public List<ProjectPayload>? Children { get; set; }
+    public List<ProjectModel>? Children { get; set; }
     public bool? IsProjectShared { get; set; }
     public string? ProjectShareOwnerName { get; set; }
     public string? ProjectShareOwnerEmail { get; set; }
@@ -24,7 +24,7 @@ public record ProjectPayload
     public bool? Deleted { get; set; }
     public int? SyncClientCreationId { get; set; }
 
-    public ProjectPayload(
+    public ProjectModel(
         string? content,
         int? id = 0,
         int? itemsCount = 0,
@@ -33,7 +33,7 @@ public record ProjectPayload
         int? parentId = null,
         bool? collapsed = false,
         int? itemOrder = null,
-        List<ProjectPayload>? children = null,
+        List<ProjectModel>? children = null,
         bool? isProjectShared = false,
         string? projectShareOwnerName = null,
         string? projectShareOwnerEmail = null,
@@ -65,7 +65,7 @@ public record ProjectPayload
 
         if (children == null)
         {
-            Children = new List<ProjectPayload>();
+            Children = new List<ProjectModel>();
         }
         else
         {

--- a/2.Views/Models/UserModel.cs
+++ b/2.Views/Models/UserModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace Todoly.Views.Models;
 
-public record UserPayload
+public record UserModel
 {
     public long? Id { get; set; } = null;
     public string? Email { get; set; }
@@ -16,7 +16,7 @@ public record UserPayload
     public int? NewTaskDueDate { get; set; } = null;
     public string? TimeZoneId { get; set; } = null;
 
-    public UserPayload(
+    public UserModel(
         string? email,
         string? password,
         string? fullName,

--- a/3.Tests/API/APITestingFramework.csproj
+++ b/3.Tests/API/APITestingFramework.csproj
@@ -23,6 +23,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <Content Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/3.Tests/API/Features/Items/Get.feature
+++ b/3.Tests/API/Features/Items/Get.feature
@@ -1,12 +1,8 @@
-Feature: Retrieve all items
-    As an authenticated user, I want to retrieve all the items of an existing project.
-    @acceptance
-    Scenario: Retrieve all items of a project
-        Given the user is authenticated with "ljorchavez@gmail.com" and "123qwe"
-        When the user makes a GET request to the API endpoint to retrieve the items of a valid project ID
-        Then the API should return an OK status code and the list of items on the project
-    @acceptance
-    Scenario: Retrieve all done items of a project
-        Given the user is authenticated
-        When the user makes a GET request to the API endpoint to retrieve the done items of a valid project ID
-        Then the API should return an OK status code and the list of done items on the project
+# Feature: Retrieve all items
+#     As an authenticated user, the user should be able to retrieve all of his created items.
+
+#     @acceptance
+#     Scenario: Retrieve all items succesfully
+#         Given the user has valid credentials
+#         When the user submits a GET request to "/items.json"
+#         Then the API should return a "OK" response with the list of all the items

--- a/3.Tests/API/Features/Items/Post.feature
+++ b/3.Tests/API/Features/Items/Post.feature
@@ -1,7 +1,13 @@
-Feature: Create a new item in a project
-    As an authenticated user, I want to be able to create a new item in an existing project
-    @acceptance
-    Scenario: Create a new item in a project
-        Given the user is authenticated
-        When the user makes a POST request to the API endpoint with a valid JSON or XML payload and ID project
-        Then the API should return an OK status code and the new item should be added to the project
+# Feature: Create a new item in a project
+#     As an authenticated user, the user should be able to create a new item
+
+#     @acceptance
+#     Scenario: Create a new item in a project
+#         Given the user has valid credentials
+#         When the user submits a POST request to "/items.json" with a valid JSON body
+#             """
+#             {
+#             "Content": "New Items",
+#             }
+#             """
+#         Then the API should return a "OK" response with the new item information

--- a/3.Tests/API/Features/Items/Put.feature
+++ b/3.Tests/API/Features/Items/Put.feature
@@ -1,7 +1,13 @@
-Feature: Update an existing item to be done
-    As an authenticated user, I want to be able to update an existing item in a project
-    @acceptance
-    Scenario: Update an existing item in a project
-        Given the user is authenticated
-        When the user makes a PUT request to the API endpoint with a valid JSON or XML payload and ID project
-        Then the API should return an OK status code and the item should be updated
+# Feature: Update an existing item by ID
+#     As an authenticated user, the user should be able to update an existing item
+
+#     @acceptance
+#     Scenario: Update an existing item information succesfully
+#         Given the user has valid credentials
+#         When the user submits a PUT request to "/items/[id].json" with a valid JSON body
+#             """
+#             {
+#             "Checked": true,
+#             }
+#             """
+#         Then the API should return a "OK" response with the updated item information

--- a/3.Tests/API/Features/Project/Delete.feature
+++ b/3.Tests/API/Features/Project/Delete.feature
@@ -1,24 +1,16 @@
-Feature: Delete a project by ID
+# Feature: Delete an existing project by ID
 
-    @acceptance
-    Scenario Outline: User deletes a project
-        Given the user is authenticated with "Valeria.Gonzales@jala.university" and "1234"
-        When the user has a valid project "<ID>"
-        Then the user sends a DELETE request to the API endpoint
-        Then the project should be removed from the list of projects
+#     @acceptance
+#     Scenario:  Delete an exsiting project succesfully
+#         Given the user has valid credentials
+#         When the user submits a DELETE request to "/projects/[id].json"
+#         Then the API should return a "OK" response with the deleted project information 
 
-        Examples:
-            | ID      |
-            | 4055226 |
-
-    @negative
-    Scenario Outline: Attempt to delete an non-existent project
-        Given the user is authenticated with "Valeria.Gonzales@jala.university" and "1234"
-        When the user has an invalid project "<ID>"
-        Then the user sends a DELETE request for the non-existent project to the API endpoint and return a "402" status code with the message: "You don't have access to this Project"
-        Then the API should return a "301" status code and an error message indicating "Invalid Id" to access the resource
-        Examples:
-            | ID    |
-            | 40547 |
+#     @negative
+#     Scenario: Fail to delete an existing project
+#         Given the user has invalid credentials
+#         When the user submits a DELETE request to "/projects/[id].json"
+#         Then the API should return a "OK" response 
+#             And a 105 status code with a "Account doesn't exist" error message
 
 

--- a/3.Tests/API/Features/Project/Delete.feature
+++ b/3.Tests/API/Features/Project/Delete.feature
@@ -11,6 +11,6 @@
 #         Given the user has invalid credentials
 #         When the user submits a DELETE request to "/projects/[id].json"
 #         Then the API should return a "OK" response 
-#             And a 105 status code with a "Account doesn't exist" error message
+#             And the API should return a 105 status code with a "Account doesn't exist" error message
 
 

--- a/3.Tests/API/Features/Project/GetAll.feature
+++ b/3.Tests/API/Features/Project/GetAll.feature
@@ -12,4 +12,4 @@
 #         Given the user has invalid credentials
 #         When the user submits a GET request to "/projects.json"
 #         Then the API should return a "OK" response 
-#             And a 105 status code with a "Account doesn't exist" error message
+#             And the API should return a 105 status code with a "Account doesn't exist" error message

--- a/3.Tests/API/Features/Project/GetAll.feature
+++ b/3.Tests/API/Features/Project/GetAll.feature
@@ -1,13 +1,15 @@
-Feature: Retrieve all existing project
+# Feature: Retrieve all existing projects
+#     As an authenticated user, the user should be able to retrieve the information of all his existing projects.
 
-    @acceptance
-    Scenario: Retrieve all projects with valid authentication
-        Given the user is authenticated
-        When the user sends a GET request to the endpoint
-        Then the response should have a status code of "OK" and the response should contain a list of all projects
+#     @acceptance
+#     Scenario: Retrieve all projects succesfully
+#         Given the user has valid credentials
+#         When the user submits a GET request to "/projects.json"
+#         Then the API should return a "OK" response with the list of all the projects
 
-    @negative
-    Scenario: Attempt to retrieve all projects without authentication
-        Given the user is not authenticated
-        When the user sends a GET request to the api endpoint
-        Then the response should have a status code of "OK" and a "Not Authenticated" error message indicating that the user is not authorized to access the resource.
+#     @negative
+#     Scenario: Fail to retrieve all projects with invalid credentials
+#         Given the user has invalid credentials
+#         When the user submits a GET request to "/projects.json"
+#         Then the API should return a "OK" response 
+#             And a 105 status code with a "Account doesn't exist" error message

--- a/3.Tests/API/Features/Project/GetById.feature
+++ b/3.Tests/API/Features/Project/GetById.feature
@@ -1,40 +1,22 @@
-Feature: Retrieve an existing project
+# Feature: Retrieve an existing project
+#     As an authenticated user, the user should be able to retrieve the information of an existing projects.
 
-    @acceptance
-    Scenario: Retrieve a specific project with valid ID and valid authentication
-        Given the user is authenticated
-        When the user sends a GET request to the api endpoint with a valid project ID
-        Then the response should have a status code of "OK" and should contain the details of the valid project
+#     @acceptance
+#     Scenario: Retrieve a specific project succesfully
+#         Given the user has valid credentials
+#         When the user submits a GET request to "/projects/[id].json"
+#         Then the API should return a "OK" response with the requested project information
 
-        Examples:
-            | Parameter              | Value                 |
-            | Id                     | 1                     |
-            | Content                | Study                 |
-            | ItemsCount             | 0                     |
-            | Icon                   | 4                     |
-            | ItemType               | 2                     |
-            | ParentId               | null                  |
-            | Collapsed              | false                 |
-            | ItemOrder              | 3                     |
-            | Children               | List<T>               |
-            | IsProjectShared        | false                 |
-            | ProjectShareOwnerName  | null                  |
-            | ProjectShareOwnerEmail | null                  |
-            | IsShareApproved        | false                 |
-            | IsOwnProject           | true                  |
-            | LastSyncedDateTime     | /Date(1674319686391)/ |
-            | LastUpdatedDate        | /Date(1674008683710)/ |
-            | Deleted                | false                 |
-            | SyncClientCreationId   | null                  |
+#     @negative
+#     Scenario: Fail to retrieve a project with invalid ID
+#         Given the user has valid credentials
+#         When the user submits a GET request to "/projects/[id].json"
+#         Then the API should return a "OK" response
+#             And a 402 status code with a "You don't have access to this Project" error message
 
-    @negative
-    Scenario: Attempt to retrieve a project with invalid ID
-        Given the user is authenticated
-        When the user sends a GET request to the api endpoint with an invalid project ID "1"
-        Then the response should have a status code of "OK" and the response should contain an error message "Not Authenticated"
-
-    @negative
-    Scenario: Attempt to retrieve a specific project with valid ID but without authentication
-        Given the user is not authenticated
-        When the user sends a GET request to the api endpoint with an valid project ID
-        Then the response should have a status code of "OK" and a "Not Authenticated" error message indicating that the user is not authorized to access the resource.
+#     @negative
+#     Scenario: Fail to retrieve a project with invalid credentials
+#         Given the user has invalid credentials
+#         When the user submits a GET request to "/projects/[id].json"
+#         Then the API should return a "OK" response 
+#             And a 105 status code with a "Account doesn't exist" error message

--- a/3.Tests/API/Features/Project/GetById.feature
+++ b/3.Tests/API/Features/Project/GetById.feature
@@ -12,11 +12,11 @@
 #         Given the user has valid credentials
 #         When the user submits a GET request to "/projects/[id].json"
 #         Then the API should return a "OK" response
-#             And a 402 status code with a "You don't have access to this Project" error message
+#             And the API should return a 402 status code with a "You don't have access to this Project" error message
 
 #     @negative
 #     Scenario: Fail to retrieve a project with invalid credentials
 #         Given the user has invalid credentials
 #         When the user submits a GET request to "/projects/[id].json"
 #         Then the API should return a "OK" response 
-#             And a 105 status code with a "Account doesn't exist" error message
+#             And the API should return a 105 status code with a "Account doesn't exist" error message

--- a/3.Tests/API/Features/Project/Post.feature
+++ b/3.Tests/API/Features/Project/Post.feature
@@ -1,34 +1,21 @@
-Feature: Project Creation
+# Feature: Project Creation
+#     As an authenticated user, the user should be able to create a new project.
 
-    @acceptance
-    Scenario: Create a new project with valid parameters and valid authentication
-        Given the user is authenticated
-        When the user sends a POST request to the API endpoint with a valid JSON or XML payload
-        Then the response should have a status code of "OK" and the new project should be added to the database and the response should contain the details of the newly created project
-            
-            Examples:
-            | Parameter              | Value                 |
-            | Id                     | 4052842               |
-            | Content                | Study                 |
-            | ItemsCount             | 0                     |
-            | Icon                   | 4                     |
-            | ItemType               | 2                     |
-            | ParentId               | null                  |
-            | Collapsed              | false                 |
-            | ItemOrder              | 3                     |
-            | Children               | List<T>               |
-            | IsProjectShared        | false                 |
-            | ProjectShareOwnerName  | null                  |
-            | ProjectShareOwnerEmail | null                  |
-            | IsShareApproved        | false                 |
-            | IsOwnProject           | true                  |
-            | LastSyncedDateTime     | /Date(1674319686391)/ |
-            | LastUpdatedDate        | /Date(1674008683710)/ |
-            | Deleted                | false                 |
-            | SyncClientCreationId   | null                  |
+#     Background: Valid Credentials
+#     Given the user has valid credentials
 
-    @negative
-    Scenario: Attempt to create a new project without valid parameters
-        Given the user is authenticated
-        When the user sends a POST request to the API endpoint with a JSON or XML payload that is missing required fields
-        Then the response should have a status code of "OK" and a error message indicating missing fields
+#     @acceptance
+#     Scenario: Create a new project succesfully
+#         When the user submits a POST request to "/projects.json" with a valid JSON body
+#             """
+#             {
+#             "Content": "New Project"
+#             }
+#             """
+#         Then the API should return a "OK" response with the new project information    
+
+#     @negative
+#     Scenario: Fail to create a new project with invalid data
+#         When the user submits a POST request to "/projects.json" with an empty body
+#         Then the API should return a "OK" response 
+#             And a 302 status code with a "Invalid input Data" error message

--- a/3.Tests/API/Features/Project/Post.feature
+++ b/3.Tests/API/Features/Project/Post.feature
@@ -18,4 +18,4 @@
 #     Scenario: Fail to create a new project with invalid data
 #         When the user submits a POST request to "/projects.json" with an empty body
 #         Then the API should return a "OK" response 
-#             And a 302 status code with a "Invalid input Data" error message
+#             And the API should return a 302 status code with a "Invalid input Data" error message

--- a/3.Tests/API/Features/Project/Put.feature
+++ b/3.Tests/API/Features/Project/Put.feature
@@ -1,22 +1,25 @@
-Feature: Update a Project by ID
+# Feature: Update an existing project by ID
 
-@acceptance
-Scenario Outline: User updates a project's information 
-    Given the user is authenticated with "Valeria.Gonzales@jala.university" and "1234"
-    When the user has a valid project "<ID>" and submits a PUT request to the API endpoint
-    Then the API should return a OK status code and the project should be updated in the database
+#     @acceptance
+#     Scenario: Update existing project information succesfully 
+#         Given the user has valid credentials
+#         When the user submits a PUT request to "/projects/[id].json" with a valid JSON body
+#             """
+#             {
+#             "Content": "New Updated Project"
+#             }
+#             """
+#         Then the API should return a "OK" response with the updated project information 
 
-Examples:
-|  ID     |
-| 4054352 |
-
-@negative  
-Scenario Outline: Update a user with invalid user credentials
-    Given the user is authenticated with "Valeria.Gonzales@jala.university" and "1234"
-    When the user has a invalid project "<ID>" and submits a PUT request to the API endpoint
-    Then the API should return a "OK" status code and an no JSON file
-
- Examples:
-|  ID   |
-| 12345 | 
+#     @negative  
+#     Scenario: Fail to update project information with invalid user credentials
+#         Given the user has invalid credentials
+#         When the user submits a PUT request to "/projects/[id].json" with a valid JSON body
+#             """
+#             {
+#             "Content": "New Updated Project"
+#             }
+#             """
+#         Then the API should return a "OK" response 
+#             And a 105 status code with a "Account doesn't exist" error message
   

--- a/3.Tests/API/Features/Project/Put.feature
+++ b/3.Tests/API/Features/Project/Put.feature
@@ -21,5 +21,5 @@
 #             }
 #             """
 #         Then the API should return a "OK" response 
-#             And a 105 status code with a "Account doesn't exist" error message
+#             And the API should return a 105 status code with a "Account doesn't exist" error message
   

--- a/3.Tests/API/Features/User/Delete.feature
+++ b/3.Tests/API/Features/User/Delete.feature
@@ -1,20 +1,15 @@
-Feature: User Deletion
-    As an authenticated user, I want to be able to delete my user account.
-    @acceptance
-    Scenario: Delete a user
-        Given the user is authenticated
-        When the user submits a POST request to "user.json" with a valid JSON body
-            """
-            {
-            "Email": "deleteUser@email.com",
-            "FullName": "Delete User",
-            "Password": "password",
-            }
-            """
-        And the user submits a DELETE request to "user/0.json" to delete his account
-        Then the API should return a "OK" status code and the deleted user information in JSON format
-    @negative
-    Scenario: Unauthorized access
-        Given the user is not authenticated
-        When the user submits a DELETE request to "user/0.json"
-        Then the API should return a "OK" response with a 102 status code and a "Not Authenticated" error message indicating that the user is not authorized to access the resource.
+# Feature: User Deletion
+#     As an authenticated user, the user should be able to delete his account.
+    
+#     @acceptance
+#     Scenario: Delete user account succesfully
+#         Given the user has valid credentials
+#         When the user submits a DELETE request to "/user/0.json"
+#         Then the API should return a "OK" response with the deleted user information
+
+#     @negative
+#     Scenario: Fail to delete user account with invalid credentials
+#         Given the user has invalid credentials
+#         When the user submits a DELETE request to "/user/0.json"
+#         Then the API should return a "OK" response
+#             And a 105 status code with a "Account doesn't exist" error message

--- a/3.Tests/API/Features/User/Delete.feature
+++ b/3.Tests/API/Features/User/Delete.feature
@@ -12,4 +12,4 @@
 #         Given the user has invalid credentials
 #         When the user submits a DELETE request to "/user/0.json"
 #         Then the API should return a "OK" response
-#             And a 105 status code with a "Account doesn't exist" error message
+#             And the API should return a 105 status code with a "Account doesn't exist" error message

--- a/3.Tests/API/Features/User/Get.feature
+++ b/3.Tests/API/Features/User/Get.feature
@@ -17,4 +17,4 @@ Feature: Retrieve user information
         Given the user has invalid credentials
         When the user submits a GET request to "/user.json"
         Then the API should return a "OK" response 
-            And a 105 status code with a "Account doesn't exist" error message
+            And the API should return a 105 status code with a "Account doesn't exist" error message

--- a/3.Tests/API/Features/User/Get.feature
+++ b/3.Tests/API/Features/User/Get.feature
@@ -1,22 +1,20 @@
-Feature: Retrieve an existing user
-    As an authenticated user, I want to be able to retrieve the information of an existing user account.
+Feature: Retrieve user information
+    As an authenticated user, the user should be able to retrieve the information of his account.
+
     @acceptance
-    Scenario: Retrieve a user
-        Given the user has a valid authentication
-        When the user submits a GET request to "user.json"
-        Then the API should return a "OK" status code and the requested user information in JSON body format
+    Scenario: Retrieve user information succesfully
+        Given the user has valid credentials
+        When the user submits a GET request to "/user.json"
+        Then the API should return a "OK" response with the requested user information
             """
             {
-                "Email": "todotesting@email.com"
+                "Email": "joaquingioffre@email.com"
             }
             """
+            
     @negative
-    Scenario: Retrieve a user with invalid user email
-        Given the user is authenticated
-        When the user submits a GET request to "user.json" with an "invalid@email.com" invalid user email
-        Then the API should return a "OK" response with a 105 status code and a "Account doesn't exist" error message indicating that the user was not found
-    @negative
-    Scenario: Unauthorized access
-        Given the user is not authenticated
-        When the user submits a GET request to "user.json"
-        Then the API should return a "OK" response with a 102 status code and a "Not Authenticated" error message indicating that the user is not authorized to access the resource.
+    Scenario: Fail to retrieve user information with invalid credentials
+        Given the user has invalid credentials
+        When the user submits a GET request to "/user.json"
+        Then the API should return a "OK" response 
+            And a 105 status code with a "Account doesn't exist" error message

--- a/3.Tests/API/Features/User/Post.feature
+++ b/3.Tests/API/Features/User/Post.feature
@@ -1,9 +1,10 @@
 Feature: User Creation
-    As a non authenticated user, I want to be able to create a new user account so that I can access to app's features.
+    As a non authenticated user, the user should be able to create a new user account to access to application's features.
+    
     @acceptance
-    Scenario: Create a new user
-        Given the user is not authenticated
-        When the user submits a POST request to "user.json" with a valid JSON body
+    Scenario: Create user account succesfully
+        Given the user has invalid credentials
+        When the user submits a POST request to "/user.json" with a valid JSON body
             """
             {
             "Email": "newUser@email.com",
@@ -11,10 +12,11 @@ Feature: User Creation
             "Password": "password",
             }
             """
-        Then the API should return a "OK" status code and the new user information in JSON format
+        Then the API should return a "OK" response with the new user information
+
     @negative
-    Scenario: Create a new user with missing required fields
-        Given the user is not authenticated
+    Scenario: Fail to create user account with missing required fields
+        Given the user has invalid credentials
         When the user submits a POST request to "user.json" with a JSON body that is missing email required fields
             """
             {
@@ -22,28 +24,19 @@ Feature: User Creation
             "Password": "password",
             }
             """
-        Then the API should return a "OK" response with a 307 status code and a "Invalid Email Address" error message indicating missing fields
+        Then the API should return a "OK" response 
+            And a 307 status code with a "Invalid Email Address" error message
+
     @negative
-    Scenario: Create a new user with invalid data
-        Given the user is not authenticated
-        When the user submits a POST request to "user.json" with a JSON body that has an invalid email
+    Scenario: Failt to create user account with an existing email account
+        Given the user has invalid credentials
+        When the user submits a POST request to "user.json" with a JSON body that has an existing email
             """
             {
-            "Email": "newUser.com",
+            "Email": "joaquingioffre@email.com",
             "FullName": "New User",
             "Password": "password",
             }
             """
-        Then the API should return a "OK" response with a 307 status code and a "Invalid Email Address" error message indicating invalid data
-    @negative
-    Scenario: Create a new user with an existing email account
-        Given the user is not authenticated
-        When the user submits a POST request to "user.json" with a JSON body that has an email previously used to create an account
-            """
-            {
-            "Email": "testingapi@email.com",
-            "FullName": "New User",
-            "Password": "password",
-            }
-            """
-        Then the API should return a "OK" response with a 201 status code and a "Account with this email address already exists" error message indicating the email already exists
+        Then the API should return a "OK" response 
+            And a 201 status code with a "Account with this email address already exists" error message

--- a/3.Tests/API/Features/User/Post.feature
+++ b/3.Tests/API/Features/User/Post.feature
@@ -25,7 +25,7 @@ Feature: User Creation
             }
             """
         Then the API should return a "OK" response 
-            And a 307 status code with a "Invalid Email Address" error message
+            And the API should return a 307 status code with a "Invalid Email Address" error message
 
     @negative
     Scenario: Failt to create user account with an existing email account
@@ -39,4 +39,4 @@ Feature: User Creation
             }
             """
         Then the API should return a "OK" response 
-            And a 201 status code with a "Account with this email address already exists" error message
+            And the API should return a 201 status code with a "Account with this email address already exists" error message

--- a/3.Tests/API/Features/User/Put.feature
+++ b/3.Tests/API/Features/User/Put.feature
@@ -1,23 +1,20 @@
-Feature: User Update
-    As an authenticated user, I want to be able to update my user account.
-    @acceptance
-    Scenario: Update a user
-        Given the user has a valid authentication
-        When the user submits a PUT request to "user/0.json" with a valid JSON body
-            """
-            {
-            "FullName": "New Name",
-            }
-            """
-        Then the API should return a "OK" status code and the updated user information in JSON format
-    @negative
-    Scenario: Update a user with invalid user credentials
-        Given the user is authenticated
-        When the user submits a PUT request to "user/0.json" with an invalid "invalid@correo" user email
-        Then the API should return a "OK" response with a 105 status code and a "Account doesn't exist" error message indicating that the user was not found
-    @negative
-    Scenario: Unauthorized access
-        Given the user is not authenticated
-        When the user submits a PUT request to "user/0.json"
-        Then the API should return a "OK" response with a 102 status code and a "Not Authenticated" error message indicating that the user is not authorized to access the resource.
+# Feature: User Update
+#     As an authenticated user, the user should be able to update his account information.
+    
+#     @acceptance
+#     Scenario: Update user information succesfully
+#         Given the user has valid credentials
+#         When the user submits a PUT request to "/user/0.json" with a valid JSON body
+#             """
+#             {
+#             "FullName": "New Name",
+#             }
+#             """
+#         Then the API should return a "OK" response with the updated user information
 
+#     @negative
+#     Scenario: Fail to update user information with invalid credentials
+#         Given the user has invalid credentials
+#         When the user submits a PUT request to "/user/0.json"
+#         Then the API should return a "OK" response
+#             And a 105 status code with a "Account doesn't exist" error message

--- a/3.Tests/API/Features/User/Put.feature
+++ b/3.Tests/API/Features/User/Put.feature
@@ -17,4 +17,4 @@
 #         Given the user has invalid credentials
 #         When the user submits a PUT request to "/user/0.json"
 #         Then the API should return a "OK" response
-#             And a 105 status code with a "Account doesn't exist" error message
+#             And the API should return a 105 status code with a "Account doesn't exist" error message

--- a/3.Tests/API/StepDefinitions/Common.cs
+++ b/3.Tests/API/StepDefinitions/Common.cs
@@ -1,47 +1,52 @@
-﻿using System;
-using DotNetEnv;
+﻿using System.Text.Json;
+using RestSharp;
 using TechTalk.SpecFlow;
 using Todoly.Core.Helpers;
+using Todoly.Views.Models;
 
 namespace Todoly.Tests.API.Steps.Commons
 {
     public class CommonSteps
     {
         private readonly ScenarioContext _scenarioContext;
-        public readonly RestHelper Client = new RestHelper("https://todo.ly/api");
+        public readonly RestHelper Client;
 
         public CommonSteps(ScenarioContext scenarioContext)
         {
-            DotNetEnv.Env.TraversePath().Load();
+            Client = new RestHelper(ConfigBuilder.Instance.GetString("api", "ApiHostUrl"));
             _scenarioContext = scenarioContext;
         }
 
-        [Given(@"the user has a valid authentication")]
-        public void Giventheuserhasavalidauthentication()
+        [Given(@"the user has (valid|invalid) credentials")]
+        public void SetCredentials(string credentials)
         {
-            _scenarioContext["Authorization"] = System.Environment.GetEnvironmentVariable(
-                "VALID_AUTHORIZATION"
-            );
+            if (credentials == "valid")
+            {
+                Client.AddAuthenticator(ConfigBuilder.Instance.GetString("TODO-LY-EMAIL"), ConfigBuilder.Instance.GetString("TODO-LY-PASS"));
+            }
+            else
+            {
+                Client.AddAuthenticator("invalidemail@email.com", "");
+            }
         }
 
-        [Given(@"the user is authenticated")]
-        public void Giventheuserisauthenticated()
+        [Then(@"the API should return a ""(.*)"" response")]
+        public void APIShouldReturnOkResponse(string response)
         {
-            _scenarioContext["Authorization"] = System.Environment.GetEnvironmentVariable(
-                "AUTHORIZATION"
-            );
-        }
-        [Given(@"the user is authenticated with ""(.*)"" and ""(.*)""")]
-        public void Giventheuserisauthenticatedwithusernameandpassword(string username, string password)
-        {
-            _scenarioContext["username"] = username;
-            _scenarioContext["password"] = password;
+            RestResponse res = (RestResponse)_scenarioContext["Response"];
+            Assert.True(res.IsSuccessful);
+            Assert.Equal(response, res.StatusCode.ToString());
         }
 
-        [Given(@"the user is not authenticated")]
-        public void Giventheuserinotsauthenticated()
+        [Then(@"a (.*) status code with a ""(.*)"" error message")]
+        public void APIShouldReturnStatusCodeAndUserNotFoundErrorMessage(int statusCode, string message)
         {
-            _scenarioContext["Authorization"] = "";
+            RestResponse res = (RestResponse)_scenarioContext["Response"];
+
+            var error = JsonSerializer.Deserialize<ErrorModel>(res.Content!);
+            Assert.IsType<ErrorModel>(error);
+            Assert.Equal(message, error!.ErrorMessage);
+            Assert.Equal(statusCode, error!.ErrorCode);
         }
     }
 }

--- a/3.Tests/API/StepDefinitions/CommonSteps.cs
+++ b/3.Tests/API/StepDefinitions/CommonSteps.cs
@@ -38,7 +38,7 @@ namespace Todoly.Tests.API.Steps.Commons
             Assert.Equal(response, res.StatusCode.ToString());
         }
 
-        [Then(@"a (.*) status code with a ""(.*)"" error message")]
+        [Then(@"the API should return a (.*) status code with a ""(.*)"" error message")]
         public void APIShouldReturnStatusCodeAndUserNotFoundErrorMessage(int statusCode, string message)
         {
             RestResponse res = (RestResponse)_scenarioContext["Response"];

--- a/3.Tests/API/StepDefinitions/Items/GetStepDefinitions.cs
+++ b/3.Tests/API/StepDefinitions/Items/GetStepDefinitions.cs
@@ -1,64 +1,64 @@
-﻿using RestSharp;
-using TechTalk.SpecFlow;
-using Todoly.Tests.API.Steps.Commons;
+﻿// using RestSharp;
+// using TechTalk.SpecFlow;
+// using Todoly.Tests.API.Steps.Commons;
 
-namespace Todoly.Tests.API.Steps.Item
-{
-    [Binding]
-    [Scope(Feature = "Retrieve all items")]
-    public class GetItemsStepDefinitions : CommonSteps
-    {
-        private readonly ScenarioContext _scenarioContext;
-        private readonly string url = "projects/4055066/items.json";
+// namespace Todoly.Tests.API.Steps.Item
+// {
+//     [Binding]
+//     [Scope(Feature = "Retrieve all items")]
+//     public class GetItemsStepDefinitions : CommonSteps
+//     {
+//         private readonly ScenarioContext _scenarioContext;
+//         private readonly string url = "projects/4055066/items.json";
 
-        public GetItemsStepDefinitions(ScenarioContext scenarioContext) : base(scenarioContext)
-        {
-            _scenarioContext = scenarioContext;
-        }
+//         public GetItemsStepDefinitions(ScenarioContext scenarioContext) : base(scenarioContext)
+//         {
+//             _scenarioContext = scenarioContext;
+//         }
 
-        [When(
-            @"the user makes a GET request to the API endpoint to retrieve the items of a valid project ID"
-        )]
-        public void WhentheusermakesaGETrequesttotheAPIendpointtoretrievetheitemsofavalidprojectID()
-        {
-            var username = _scenarioContext["username"].ToString();
-            var password = _scenarioContext["password"].ToString();
-            Client.AddDefaultHeader("Accept", "*/*");
-            Client.AddAuthenticator(username: username!, password: password!);
+//         [When(
+//             @"the user makes a GET request to the API endpoint to retrieve the items of a valid project ID"
+//         )]
+//         public void WhentheusermakesaGETrequesttotheAPIendpointtoretrievetheitemsofavalidprojectID()
+//         {
+//             var username = _scenarioContext["username"].ToString();
+//             var password = _scenarioContext["password"].ToString();
+//             Client.AddDefaultHeader("Accept", "*/*");
+//             Client.AddAuthenticator(username: username!, password: password!);
 
-            _scenarioContext["Response"] = Client.Get(url);
-        }
+//             _scenarioContext["Response"] = Client.Get(url);
+//         }
 
-        [Then(@"the API should return an (.*) status code and the list of items on the project")]
-        public void ThentheAPIshouldreturnanstatuscodeandthelistofitemsontheproject(
-            string statusCode
-        )
-        {
-            RestResponse response = (RestResponse)_scenarioContext["Response"];
-            Assert.Equal(statusCode, response.StatusCode.ToString());
-        }
+//         [Then(@"the API should return an (.*) status code and the list of items on the project")]
+//         public void ThentheAPIshouldreturnanstatuscodeandthelistofitemsontheproject(
+//             string statusCode
+//         )
+//         {
+//             RestResponse response = (RestResponse)_scenarioContext["Response"];
+//             Assert.Equal(statusCode, response.StatusCode.ToString());
+//         }
 
-        [When(
-            @"the user makes a GET request to the API endpoint to retrieve the done items of a valid project ID"
-        )]
-        public void WhentheusermakesaGETrequesttotheAPIendpointtoretrievethedoneitemsofavalidprojectID()
-        {
-            Client.AddDefaultHeader("Authorization", _scenarioContext["Authorization"].ToString()!);
-            Client.AddDefaultHeader("Accept", "*/*");
+//         [When(
+//             @"the user makes a GET request to the API endpoint to retrieve the done items of a valid project ID"
+//         )]
+//         public void WhentheusermakesaGETrequesttotheAPIendpointtoretrievethedoneitemsofavalidprojectID()
+//         {
+//             Client.AddDefaultHeader("Authorization", _scenarioContext["Authorization"].ToString()!);
+//             Client.AddDefaultHeader("Accept", "*/*");
 
-            _scenarioContext["Response"] = Client.Get(url);
-        }
+//             _scenarioContext["Response"] = Client.Get(url);
+//         }
 
-        [Then(
-            @"the API should return an (.*) status code and the list of done items on the project"
-        )]
-        public void ThentheAPIshouldreturnanstatuscodeandthelistofdoneitemsontheproject(
-            string statusCode
-        )
-        {
-            RestResponse response = (RestResponse)_scenarioContext["Response"];
-            Assert.True(response.IsSuccessful);
-            Assert.Equal(statusCode, response.StatusCode.ToString());
-        }
-    }
-}
+//         [Then(
+//             @"the API should return an (.*) status code and the list of done items on the project"
+//         )]
+//         public void ThentheAPIshouldreturnanstatuscodeandthelistofdoneitemsontheproject(
+//             string statusCode
+//         )
+//         {
+//             RestResponse response = (RestResponse)_scenarioContext["Response"];
+//             Assert.True(response.IsSuccessful);
+//             Assert.Equal(statusCode, response.StatusCode.ToString());
+//         }
+//     }
+// }

--- a/3.Tests/API/StepDefinitions/Items/PostStepDefinitions.cs
+++ b/3.Tests/API/StepDefinitions/Items/PostStepDefinitions.cs
@@ -1,69 +1,69 @@
-﻿using RestSharp;
-using TechTalk.SpecFlow;
-using Todoly.Tests.API.Steps.Commons;
-using Todoly.Views.Models;
+﻿// using RestSharp;
+// using TechTalk.SpecFlow;
+// using Todoly.Tests.API.Steps.Commons;
+// using Todoly.Views.Models;
 
-namespace Todoly.Tests.API.Steps.Item
-{
-    [Binding]
-    [Scope(Feature = "Create a new item in a project")]
-    public class PostStepDefinitions : CommonSteps
-    {
-        private readonly ScenarioContext _scenarioContext;
-        private readonly string url = "items.json";
+// namespace Todoly.Tests.API.Steps.Item
+// {
+//     [Binding]
+//     [Scope(Feature = "Create a new item in a project")]
+//     public class PostStepDefinitions : CommonSteps
+//     {
+//         private readonly ScenarioContext _scenarioContext;
+//         private readonly string url = "items.json";
 
-        public PostStepDefinitions(ScenarioContext scenarioContext)
-            : base(scenarioContext)
-        {
-            _scenarioContext = scenarioContext;
-        }
+//         public PostStepDefinitions(ScenarioContext scenarioContext)
+//             : base(scenarioContext)
+//         {
+//             _scenarioContext = scenarioContext;
+//         }
 
-        [When(
-            @"the user makes a POST request to the API endpoint with a valid JSON or XML payload and ID project"
-        )]
-        public void WhentheusermakesaPOSTrequesttotheAPIendpointwithavalidJSONorXMLpayloadandIDproject()
-        {
-            ItemsPayload body = new ItemsPayload(
-                null,
-                content: "This is a new item",
-                null,
-                null,
-                projectId: 4053023,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
-            _scenarioContext["Response"] = Client.Post<ItemsPayload>(url, body);
-        }
+//         [When(
+//             @"the user makes a POST request to the API endpoint with a valid JSON or XML payload and ID project"
+//         )]
+//         public void WhentheusermakesaPOSTrequesttotheAPIendpointwithavalidJSONorXMLpayloadandIDproject()
+//         {
+//             ItemModel body = new ItemModel(
+//                 null,
+//                 content: "This is a new item",
+//                 null,
+//                 null,
+//                 projectId: 4053023,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null
+//             );
+//             _scenarioContext["Response"] = Client.Post<ItemModel>(url, body);
+//         }
 
-        [Then(
-            @"the API should return an (.*) status code and the new item should be added to the project"
-        )]
-        public void ThentheAPIshouldreturnanstatuscodeandthenewitemshouldbeaddedtotheproject(
-            string statusCode
-        )
-        {
-            RestResponse response = (RestResponse)_scenarioContext["Response"];
-            Assert.True(response.IsSuccessful);
-            Assert.Equal(statusCode, response.StatusCode.ToString());
-        }
-    }
-}
+//         [Then(
+//             @"the API should return an (.*) status code and the new item should be added to the project"
+//         )]
+//         public void ThentheAPIshouldreturnanstatuscodeandthenewitemshouldbeaddedtotheproject(
+//             string statusCode
+//         )
+//         {
+//             RestResponse response = (RestResponse)_scenarioContext["Response"];
+//             Assert.True(response.IsSuccessful);
+//             Assert.Equal(statusCode, response.StatusCode.ToString());
+//         }
+//     }
+// }

--- a/3.Tests/API/StepDefinitions/Items/PutStepDefinitions.cs
+++ b/3.Tests/API/StepDefinitions/Items/PutStepDefinitions.cs
@@ -1,65 +1,65 @@
-﻿using RestSharp;
-using TechTalk.SpecFlow;
-using Todoly.Tests.API.Steps.Commons;
-using Todoly.Views.Models;
+﻿// using RestSharp;
+// using TechTalk.SpecFlow;
+// using Todoly.Tests.API.Steps.Commons;
+// using Todoly.Views.Models;
 
-namespace Todoly.Tests.API.Steps.Item
-{
-    [Binding]
-    [Scope(Feature = "Update an existing item to be done")]
-    public class PutStepDefinitions : CommonSteps
-    {
-        private readonly ScenarioContext _scenarioContext;
-        private readonly string url = "items/11099581.json";
+// namespace Todoly.Tests.API.Steps.Item
+// {
+//     [Binding]
+//     [Scope(Feature = "Update an existing item to be done")]
+//     public class PutStepDefinitions : CommonSteps
+//     {
+//         private readonly ScenarioContext _scenarioContext;
+//         private readonly string url = "items/11099581.json";
 
-        public PutStepDefinitions(ScenarioContext scenarioContext)
-            : base(scenarioContext)
-        {
-            _scenarioContext = scenarioContext;
-        }
+//         public PutStepDefinitions(ScenarioContext scenarioContext)
+//             : base(scenarioContext)
+//         {
+//             _scenarioContext = scenarioContext;
+//         }
 
-        [When(
-            @"the user makes a PUT request to the API endpoint with a valid JSON or XML payload and ID project"
-        )]
-        public void WhentheusermakesaPUTrequesttotheAPIendpointwithavalidJSONorXMLpayloadandIDproject()
-        {
-            ItemsPayload body = new ItemsPayload(
-                null,
-                null,
-                null,
-                true,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
-            _scenarioContext["Response"] = Client.Put<ItemsPayload>(url, body);
-        }
+//         [When(
+//             @"the user makes a PUT request to the API endpoint with a valid JSON or XML payload and ID project"
+//         )]
+//         public void WhentheusermakesaPUTrequesttotheAPIendpointwithavalidJSONorXMLpayloadandIDproject()
+//         {
+//             ItemModel body = new ItemModel(
+//                 null,
+//                 null,
+//                 null,
+//                 true,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null
+//             );
+//             _scenarioContext["Response"] = Client.Put<ItemModel>(url, body);
+//         }
 
-        [Then(@"the API should return an (.*) status code and the item should be updated")]
-        public void ThentheAPIshouldreturnanstatuscodeandtheitemshouldbeupdated(string statusCode)
-        {
-            RestResponse response = (RestResponse)_scenarioContext["Response"];
-            Assert.True(response.IsSuccessful);
-            Assert.Equal(statusCode, response.StatusCode.ToString());
-        }
-    }
-}
+//         [Then(@"the API should return an (.*) status code and the item should be updated")]
+//         public void ThentheAPIshouldreturnanstatuscodeandtheitemshouldbeupdated(string statusCode)
+//         {
+//             RestResponse response = (RestResponse)_scenarioContext["Response"];
+//             Assert.True(response.IsSuccessful);
+//             Assert.Equal(statusCode, response.StatusCode.ToString());
+//         }
+//     }
+// }

--- a/3.Tests/API/StepDefinitions/Project/DeleteByIdStepDefinitions.cs
+++ b/3.Tests/API/StepDefinitions/Project/DeleteByIdStepDefinitions.cs
@@ -1,100 +1,100 @@
-﻿using System.Text.Json;
-using RestSharp;
-using TechTalk.SpecFlow;
-using Todoly.Tests.API.Steps.Commons;
-using Todoly.Views.Models;
+﻿// using System.Text.Json;
+// using RestSharp;
+// using TechTalk.SpecFlow;
+// using Todoly.Tests.API.Steps.Commons;
+// using Todoly.Views.Models;
 
-namespace Todoly.Tests.API.Steps.Project
-{
-    [Binding]
-    [Scope(Feature = "Delete a project by ID")]
-    public class DeleteProjectStepDefinitions : CommonSteps
-    {
-        private readonly ScenarioContext _scenarioContext;
-        private string ApiUrl = "";
+// namespace Todoly.Tests.API.Steps.Project
+// {
+//     [Binding]
+//     [Scope(Feature = "Delete a project by ID")]
+//     public class DeleteProjectStepDefinitions : CommonSteps
+//     {
+//         private readonly ScenarioContext _scenarioContext;
+//         private string ApiUrl = "";
 
-        public DeleteProjectStepDefinitions(ScenarioContext scenarioContext) : base(scenarioContext)
-        {
-            _scenarioContext = scenarioContext;
-        }
+//         public DeleteProjectStepDefinitions(ScenarioContext scenarioContext) : base(scenarioContext)
+//         {
+//             _scenarioContext = scenarioContext;
+//         }
 
-        [When(@"the user has a valid project ""(.*)""")]
-        public void Thentheusershouldre(int expectedId)
-        {
-            ApiUrl = $"projects/{expectedId}.json";
-            var username = _scenarioContext["username"].ToString();
-            var password = _scenarioContext["password"].ToString();
-            Client.AddDefaultHeader("Accept", "*/*");
-            Client.AddAuthenticator(username: username!, password: password!);
+//         [When(@"the user has a valid project ""(.*)""")]
+//         public void Thentheusershouldre(int expectedId)
+//         {
+//             ApiUrl = $"projects/{expectedId}.json";
+//             var username = _scenarioContext["username"].ToString();
+//             var password = _scenarioContext["password"].ToString();
+//             Client.AddDefaultHeader("Accept", "*/*");
+//             Client.AddAuthenticator(username: username!, password: password!);
 
-            _scenarioContext["Response"] = Client.Get(ApiUrl);
-            var response = (RestResponse)_scenarioContext["Response"];
+//             _scenarioContext["Response"] = Client.Get(ApiUrl);
+//             var response = (RestResponse)_scenarioContext["Response"];
 
-            Assert.True(response.IsSuccessful);
-            var project = JsonSerializer.Deserialize<ProjectPayload>(
-                response.Content!.ToString()
-            );
-            Assert.Equal(project!.Id, expectedId);
-        }
+//             Assert.True(response.IsSuccessful);
+//             var project = JsonSerializer.Deserialize<ProjectModel>(
+//                 response.Content!.ToString()
+//             );
+//             Assert.Equal(project!.Id, expectedId);
+//         }
 
-        [Then(@"the user sends a DELETE request to the API endpoint")]
-        public void WhentheusersendsaDELETErequesttotheendpoint()
-        {
-            //_scenarioContext["Response"] = Client.Delete(ApiUrl);
-            //var response = (RestResponse)_scenarioContext["Response"];
-        }
+//         [Then(@"the user sends a DELETE request to the API endpoint")]
+//         public void WhentheusersendsaDELETErequesttotheendpoint()
+//         {
+//             //_scenarioContext["Response"] = Client.Delete(ApiUrl);
+//             //var response = (RestResponse)_scenarioContext["Response"];
+//         }
 
-        [Then(@"the project should be removed from the list of projects")]
-        public void Thentheprojectshouldberemovedfromthelistofprojects()
-        {
-            _scenarioContext["Response"] = Client.Get(ApiUrl);
-            var response = (RestResponse)_scenarioContext["Response"];
-            Assert.NotEmpty(response.Content!);
-        }
+//         [Then(@"the project should be removed from the list of projects")]
+//         public void Thentheprojectshouldberemovedfromthelistofprojects()
+//         {
+//             _scenarioContext["Response"] = Client.Get(ApiUrl);
+//             var response = (RestResponse)_scenarioContext["Response"];
+//             Assert.NotEmpty(response.Content!);
+//         }
 
-        [When(@"the user has an invalid project ""(.*)""")]
-        public void GiventheuserhasaninvalidprojectID(long id)
-        {
-            ApiUrl = $"projects/{id}.json";
-            Client.AddDefaultHeader(
-                "Authorization",
-                "Basic VmFsZXJpYS5Hb256YWxlc0BqYWxhLnVuaXZlcnNpdHk6MTIzNA=="
-            );
-            Client.AddDefaultHeader("Accept", "*/*");
-        }
+//         [When(@"the user has an invalid project ""(.*)""")]
+//         public void GiventheuserhasaninvalidprojectID(long id)
+//         {
+//             ApiUrl = $"projects/{id}.json";
+//             Client.AddDefaultHeader(
+//                 "Authorization",
+//                 "Basic VmFsZXJpYS5Hb256YWxlc0BqYWxhLnVuaXZlcnNpdHk6MTIzNA=="
+//             );
+//             Client.AddDefaultHeader("Accept", "*/*");
+//         }
 
-        [Then(
-            @"the user sends a DELETE request for the non-existent project to the API endpoint and return a ""(.*)"" status code with the message: ""(.*)"""
-        )]
-        public void WhentheusersendsaDELETErequestforthenonexistentprojecttotheAPIendpoint(
-            int expectedErrorCode,
-            string expectedErrorMessage
-        )
-        {
-            _scenarioContext["Response"] = Client.Get(ApiUrl);
-            var response = (RestResponse)_scenarioContext["Response"];
-            ErrorResponseModel? project = JsonSerializer.Deserialize<ErrorResponseModel>(
-                response.Content!
-            );
-            Assert.Equal(project!.ErrorCode, expectedErrorCode);
-            Assert.Equal(project!.ErrorMessage, expectedErrorMessage);
-        }
+//         [Then(
+//             @"the user sends a DELETE request for the non-existent project to the API endpoint and return a ""(.*)"" status code with the message: ""(.*)"""
+//         )]
+//         public void WhentheusersendsaDELETErequestforthenonexistentprojecttotheAPIendpoint(
+//             int expectedErrorCode,
+//             string expectedErrorMessage
+//         )
+//         {
+//             _scenarioContext["Response"] = Client.Get(ApiUrl);
+//             var response = (RestResponse)_scenarioContext["Response"];
+//             ErrorModel? project = JsonSerializer.Deserialize<ErrorModel>(
+//                 response.Content!
+//             );
+//             Assert.Equal(project!.ErrorCode, expectedErrorCode);
+//             Assert.Equal(project!.ErrorMessage, expectedErrorMessage);
+//         }
 
-        [Then(
-            @"the API should return a ""(.*)"" status code and an error message indicating ""(.*)"" to access the resource"
-        )]
-        public void ThentheAPIshouldreturna401statuscodeandanerrormessageindicatingthattheuserisnotauthorizedtoaccesstheresource(
-            int expectedErrorCode,
-            string expectedErrorMessage
-        )
-        {
-            _scenarioContext["Response"] = Client.Delete(ApiUrl);
-            var response = (RestResponse)_scenarioContext["Response"];
-            ErrorResponseModel? project = JsonSerializer.Deserialize<ErrorResponseModel>(
-                response.Content!
-            );
-            Assert.Equal(project!.ErrorCode, expectedErrorCode);
-            Assert.Equal(project!.ErrorMessage, expectedErrorMessage);
-        }
-    }
-}
+//         [Then(
+//             @"the API should return a ""(.*)"" status code and an error message indicating ""(.*)"" to access the resource"
+//         )]
+//         public void ThentheAPIshouldreturna401statuscodeandanerrormessageindicatingthattheuserisnotauthorizedtoaccesstheresource(
+//             int expectedErrorCode,
+//             string expectedErrorMessage
+//         )
+//         {
+//             _scenarioContext["Response"] = Client.Delete(ApiUrl);
+//             var response = (RestResponse)_scenarioContext["Response"];
+//             ErrorModel? project = JsonSerializer.Deserialize<ErrorModel>(
+//                 response.Content!
+//             );
+//             Assert.Equal(project!.ErrorCode, expectedErrorCode);
+//             Assert.Equal(project!.ErrorMessage, expectedErrorMessage);
+//         }
+//     }
+// }

--- a/3.Tests/API/StepDefinitions/Project/GetAllStepDefinitions.cs
+++ b/3.Tests/API/StepDefinitions/Project/GetAllStepDefinitions.cs
@@ -1,62 +1,62 @@
-﻿using System.Text.Json;
-using RestSharp;
-using TechTalk.SpecFlow;
-using Todoly.Tests.API.Steps.Commons;
-using Todoly.Views.Models;
+﻿// using System.Text.Json;
+// using RestSharp;
+// using TechTalk.SpecFlow;
+// using Todoly.Tests.API.Steps.Commons;
+// using Todoly.Views.Models;
 
-namespace Todoly.Tests.API.Steps.Project
-{
-    [Binding]
-    [Scope(Feature = "Retrieve all existing project")]
-    public class GetAllStepDefinitions : CommonSteps
-    {
-        private readonly ScenarioContext _scenarioContext;
-        private readonly string url = "projects.json";
+// namespace Todoly.Tests.API.Steps.Project
+// {
+//     [Binding]
+//     [Scope(Feature = "Retrieve all existing project")]
+//     public class GetAllStepDefinitions : CommonSteps
+//     {
+//         private readonly ScenarioContext _scenarioContext;
+//         private readonly string url = "projects.json";
 
-        public GetAllStepDefinitions(ScenarioContext scenarioContext) : base(scenarioContext)
-        {
-            _scenarioContext = scenarioContext;
-        }
+//         public GetAllStepDefinitions(ScenarioContext scenarioContext) : base(scenarioContext)
+//         {
+//             _scenarioContext = scenarioContext;
+//         }
 
-        [When(@"the user sends a GET request to the endpoint")]
-        public void WhentheusersendsaGETrequesttotheendpoint()
-        {
-            Client.AddDefaultHeader("Authorization", _scenarioContext["Authorization"].ToString()!);
-            Client.AddDefaultHeader("Accept", "*/*");
+//         [When(@"the user sends a GET request to the endpoint")]
+//         public void WhentheusersendsaGETrequesttotheendpoint()
+//         {
+//             Client.AddDefaultHeader("Authorization", _scenarioContext["Authorization"].ToString()!);
+//             Client.AddDefaultHeader("Accept", "*/*");
 
-            _scenarioContext["Response"] = Client.Get(url);
-        }
+//             _scenarioContext["Response"] = Client.Get(url);
+//         }
 
-        [Then(@"the response should have a status code of ""(.*)"" and the response should contain a list of all projects")]
-        public void Thentheresponseshouldhaveastatuscodeofandtheresponseshouldcontainalistofallprojects(string statusCode)
-        {
-            RestResponse response = (RestResponse)_scenarioContext["Response"];
-            Assert.Equal(statusCode, response.StatusCode.ToString());
+//         [Then(@"the response should have a status code of ""(.*)"" and the response should contain a list of all projects")]
+//         public void Thentheresponseshouldhaveastatuscodeofandtheresponseshouldcontainalistofallprojects(string statusCode)
+//         {
+//             RestResponse response = (RestResponse)_scenarioContext["Response"];
+//             Assert.Equal(statusCode, response.StatusCode.ToString());
 
-            var user = JsonSerializer.Deserialize<ProjectPayload>(response.Content!);
-            Assert.IsType<ProjectPayload>(user);
-        }
+//             var user = JsonSerializer.Deserialize<ProjectModel>(response.Content!);
+//             Assert.IsType<ProjectModel>(user);
+//         }
 
-        [When(@"the user sends a GET request to the api endpoint")]
-        public void WhentheusersendsaGETrequesttotheapiendpoint()
-        {
-            Client.AddDefaultHeader("Accept", "*/*");
+//         [When(@"the user sends a GET request to the api endpoint")]
+//         public void WhentheusersendsaGETrequesttotheapiendpoint()
+//         {
+//             Client.AddDefaultHeader("Accept", "*/*");
 
-            _scenarioContext["Response"] = Client.Get(url);
-        }
+//             _scenarioContext["Response"] = Client.Get(url);
+//         }
 
-        [Then(@"the response should have a status code of ""(.*)"" and a ""(.*)"" error message indicating that the user is not authorized to access the resource.")]
-        public void Thentheresponseshouldhaveastatuscodeofandaerrormessageindicatingthattheuserisnotauthorizedtoaccesstheresource(string statusCode, string errorMessage)
-        {
-            RestResponse response = (RestResponse)_scenarioContext["Response"];
+//         [Then(@"the response should have a status code of ""(.*)"" and a ""(.*)"" error message indicating that the user is not authorized to access the resource.")]
+//         public void Thentheresponseshouldhaveastatuscodeofandaerrormessageindicatingthattheuserisnotauthorizedtoaccesstheresource(string statusCode, string errorMessage)
+//         {
+//             RestResponse response = (RestResponse)_scenarioContext["Response"];
 
-            Assert.True(response.IsSuccessful);
-            Assert.Equal(statusCode, response.StatusCode.ToString());
+//             Assert.True(response.IsSuccessful);
+//             Assert.Equal(statusCode, response.StatusCode.ToString());
 
-            var error = JsonSerializer.Deserialize<ErrorResponseModel>(response.Content!);
-            Assert.IsType<ErrorResponseModel>(error);
-            Assert.Equal(errorMessage, error!.ErrorMessage);
-            Assert.Equal(102, error!.ErrorCode);
-        }
-    }
-}
+//             var error = JsonSerializer.Deserialize<ErrorModel>(response.Content!);
+//             Assert.IsType<ErrorModel>(error);
+//             Assert.Equal(errorMessage, error!.ErrorMessage);
+//             Assert.Equal(102, error!.ErrorCode);
+//         }
+//     }
+// }

--- a/3.Tests/API/StepDefinitions/Project/GetByIdStepDefinitions.cs
+++ b/3.Tests/API/StepDefinitions/Project/GetByIdStepDefinitions.cs
@@ -1,106 +1,106 @@
-﻿using System.Text.Json;
-using RestSharp;
-using TechTalk.SpecFlow;
-using Todoly.Tests.API.Steps.Commons;
-using Todoly.Views.Models;
+﻿// using System.Text.Json;
+// using RestSharp;
+// using TechTalk.SpecFlow;
+// using Todoly.Tests.API.Steps.Commons;
+// using Todoly.Views.Models;
 
-namespace Todoly.Tests.API.Steps.Project
-{
-    [Binding]
-    [Scope(Feature = "Retrieve an existing project")]
-    public class GetByIdStepDefinitions : CommonSteps
-    {
-        private readonly ScenarioContext _scenarioContext;
-        private readonly string url = "projects.json";
+// namespace Todoly.Tests.API.Steps.Project
+// {
+//     [Binding]
+//     [Scope(Feature = "Retrieve an existing project")]
+//     public class GetByIdStepDefinitions : CommonSteps
+//     {
+//         private readonly ScenarioContext _scenarioContext;
+//         private readonly string url = "projects.json";
 
-        public GetByIdStepDefinitions(ScenarioContext scenarioContext) : base(scenarioContext)
-        {
-            _scenarioContext = scenarioContext;
-        }
+//         public GetByIdStepDefinitions(ScenarioContext scenarioContext) : base(scenarioContext)
+//         {
+//             _scenarioContext = scenarioContext;
+//         }
 
-        [When(@"the user sends a GET request to the api endpoint with a valid project ID")]
-        public void WhentheusersendsaGETrequesttotheapiendpointwithavalidprojectID()
-        {
-            Client.AddDefaultHeader("Authorization", _scenarioContext["Authorization"].ToString()!);
-            Client.AddDefaultHeader("Accept", "*/*");
+//         [When(@"the user sends a GET request to the api endpoint with a valid project ID")]
+//         public void WhentheusersendsaGETrequesttotheapiendpointwithavalidprojectID()
+//         {
+//             Client.AddDefaultHeader("Authorization", _scenarioContext["Authorization"].ToString()!);
+//             Client.AddDefaultHeader("Accept", "*/*");
 
-            _scenarioContext["Response"] = Client.Get(url);
-        }
+//             _scenarioContext["Response"] = Client.Get(url);
+//         }
 
-        [Then(
-            @"the response should have a status code of ""(.*)"" and should contain the details of the valid project"
-        )]
-        public void Thentheresponseshouldhaveastatuscodeofandshouldcontainthedetailsofthevalidproject(
-            string statusCode
-        )
-        {
-            RestResponse response = (RestResponse)_scenarioContext["Response"];
+//         [Then(
+//             @"the response should have a status code of ""(.*)"" and should contain the details of the valid project"
+//         )]
+//         public void Thentheresponseshouldhaveastatuscodeofandshouldcontainthedetailsofthevalidproject(
+//             string statusCode
+//         )
+//         {
+//             RestResponse response = (RestResponse)_scenarioContext["Response"];
 
-            Assert.True(response.IsSuccessful);
-            Assert.Equal(statusCode, response.StatusCode.ToString());
+//             Assert.True(response.IsSuccessful);
+//             Assert.Equal(statusCode, response.StatusCode.ToString());
 
-            var user = JsonSerializer.Deserialize<ProjectPayload>(response.Content!);
-            Assert.IsType<ProjectPayload>(user);
-        }
+//             var user = JsonSerializer.Deserialize<ProjectModel>(response.Content!);
+//             Assert.IsType<ProjectModel>(user);
+//         }
 
-        [When(
-            @"the user sends a GET request to the api endpoint with an invalid project ID ""(.*)"""
-        )]
-        public void WhentheusersendsaGETrequesttotheapiendpointwithaninvalidprojectID(string id)
-        {
-            Client.AddDefaultHeader(
-                "Authorization",
-                "Basic YWRyaWVsLmdpbWVuZXNAamFsYS51bml2ZXJzaXR5OlRvZG8ubHkzMjY4MA=="
-            );
-            Client.AddDefaultHeader("Accept", "*/*");
+//         [When(
+//             @"the user sends a GET request to the api endpoint with an invalid project ID ""(.*)"""
+//         )]
+//         public void WhentheusersendsaGETrequesttotheapiendpointwithaninvalidprojectID(string id)
+//         {
+//             Client.AddDefaultHeader(
+//                 "Authorization",
+//                 "Basic YWRyaWVsLmdpbWVuZXNAamFsYS51bml2ZXJzaXR5OlRvZG8ubHkzMjY4MA=="
+//             );
+//             Client.AddDefaultHeader("Accept", "*/*");
 
-            _scenarioContext["Response"] = Client.Get($"projects/{id}.json");
-        }
+//             _scenarioContext["Response"] = Client.Get($"projects/{id}.json");
+//         }
 
-        [Then(
-            @"the response should have a status code of ""(.*)"" and the response should contain an error message ""(.*)"""
-        )]
-        public void Thentheresponseshouldhaveastatuscodeofandtheresponseshouldcontainanerrormessage(
-            string statusCode,
-            string errorMessage
-        )
-        {
-            RestResponse response = (RestResponse)_scenarioContext["Response"];
+//         [Then(
+//             @"the response should have a status code of ""(.*)"" and the response should contain an error message ""(.*)"""
+//         )]
+//         public void Thentheresponseshouldhaveastatuscodeofandtheresponseshouldcontainanerrormessage(
+//             string statusCode,
+//             string errorMessage
+//         )
+//         {
+//             RestResponse response = (RestResponse)_scenarioContext["Response"];
 
-            Assert.True(response.IsSuccessful);
-            Assert.Equal(statusCode, response.StatusCode.ToString());
+//             Assert.True(response.IsSuccessful);
+//             Assert.Equal(statusCode, response.StatusCode.ToString());
 
-            var error = JsonSerializer.Deserialize<ErrorResponseModel>(response.Content!);
-            Assert.IsType<ErrorResponseModel>(error);
-            Assert.Equal(errorMessage, error!.ErrorMessage);
-            Assert.Equal(102, error!.ErrorCode);
-        }
+//             var error = JsonSerializer.Deserialize<ErrorModel>(response.Content!);
+//             Assert.IsType<ErrorModel>(error);
+//             Assert.Equal(errorMessage, error!.ErrorMessage);
+//             Assert.Equal(102, error!.ErrorCode);
+//         }
 
-        [When(@"the user sends a GET request to the api endpoint with an valid project ID")]
-        public void WhentheusersendsaGETrequesttotheapiendpointwithanvalidprojectID()
-        {
-            Client.AddDefaultHeader("Accept", "*/*");
+//         [When(@"the user sends a GET request to the api endpoint with an valid project ID")]
+//         public void WhentheusersendsaGETrequesttotheapiendpointwithanvalidprojectID()
+//         {
+//             Client.AddDefaultHeader("Accept", "*/*");
 
-            _scenarioContext["Response"] = Client.Get(url);
-        }
+//             _scenarioContext["Response"] = Client.Get(url);
+//         }
 
-        [Then(
-            @"the response should have a status code of ""(.*)"" and a ""(.*)"" error message indicating that the user is not authorized to access the resource."
-        )]
-        public void Thentheresponseshouldhaveastatuscodeofandaerrormessageindicatingthattheuserisnotauthorizedtoaccesstheresource(
-            string statusCode,
-            string errorMessage
-        )
-        {
-            RestResponse response = (RestResponse)_scenarioContext["Response"];
+//         [Then(
+//             @"the response should have a status code of ""(.*)"" and a ""(.*)"" error message indicating that the user is not authorized to access the resource."
+//         )]
+//         public void Thentheresponseshouldhaveastatuscodeofandaerrormessageindicatingthattheuserisnotauthorizedtoaccesstheresource(
+//             string statusCode,
+//             string errorMessage
+//         )
+//         {
+//             RestResponse response = (RestResponse)_scenarioContext["Response"];
 
-            Assert.True(response.IsSuccessful);
-            Assert.Equal(statusCode, response.StatusCode.ToString());
+//             Assert.True(response.IsSuccessful);
+//             Assert.Equal(statusCode, response.StatusCode.ToString());
 
-            var error = JsonSerializer.Deserialize<ErrorResponseModel>(response.Content!);
-            Assert.IsType<ErrorResponseModel>(error);
-            Assert.Equal(errorMessage, error!.ErrorMessage);
-            Assert.Equal(102, error!.ErrorCode);
-        }
-    }
-}
+//             var error = JsonSerializer.Deserialize<ErrorModel>(response.Content!);
+//             Assert.IsType<ErrorModel>(error);
+//             Assert.Equal(errorMessage, error!.ErrorMessage);
+//             Assert.Equal(102, error!.ErrorCode);
+//         }
+//     }
+// }

--- a/3.Tests/API/StepDefinitions/Project/PostStepDefinitions.cs
+++ b/3.Tests/API/StepDefinitions/Project/PostStepDefinitions.cs
@@ -1,75 +1,75 @@
-﻿using System.Text.Json;
-using RestSharp;
-using TechTalk.SpecFlow;
-using Todoly.Tests.API.Steps.Commons;
-using Todoly.Views.Models;
+﻿// using System.Text.Json;
+// using RestSharp;
+// using TechTalk.SpecFlow;
+// using Todoly.Tests.API.Steps.Commons;
+// using Todoly.Views.Models;
 
-namespace Todoly.Tests.API.Steps.Project
-{
-    [Binding]
-    [Scope(Feature = "Project Creation")]
-    public class PostStepDefinitions : CommonSteps
-    {
-        private readonly ScenarioContext _scenarioContext;
-        private readonly string url = "projects.json";
+// namespace Todoly.Tests.API.Steps.Project
+// {
+//     [Binding]
+//     [Scope(Feature = "Project Creation")]
+//     public class PostStepDefinitions : CommonSteps
+//     {
+//         private readonly ScenarioContext _scenarioContext;
+//         private readonly string url = "projects.json";
 
-        public PostStepDefinitions(ScenarioContext scenarioContext) : base(scenarioContext)
-        {
-            _scenarioContext = scenarioContext;
-        }
+//         public PostStepDefinitions(ScenarioContext scenarioContext) : base(scenarioContext)
+//         {
+//             _scenarioContext = scenarioContext;
+//         }
 
-        [When(@"the user sends a POST request to the API endpoint with a valid JSON or XML payload")]
-        public void WhentheusersendsaPOSTrequesttotheAPIendpointwithavalidJSONorXMLpayload()
-        {
-            ProjectPayload body = new ProjectPayload("My New Project");
-            _scenarioContext["Response"] = Client.Post<ProjectPayload>(url, body);
-        }
+//         [When(@"the user sends a POST request to the API endpoint with a valid JSON or XML payload")]
+//         public void WhentheusersendsaPOSTrequesttotheAPIendpointwithavalidJSONorXMLpayload()
+//         {
+//             ProjectModel body = new ProjectModel("My New Project");
+//             _scenarioContext["Response"] = Client.Post<ProjectModel>(url, body);
+//         }
 
-        [Then(@"the response should have a status code of ""(.*)"" and the new project should be added to the database and the response should contain the details of the newly created project")]
-        public void Thentheresponseshouldhaveastatuscodeofandthenewprojectshouldbeaddedtothedatabaseandtheresponseshouldcontainthedetailsofthenewlycreatedproject(string statusCode)
-        {
-            RestResponse response = (RestResponse)_scenarioContext["Response"];
-            Assert.True(response.IsSuccessful);
-            Assert.Equal(statusCode, response.StatusCode.ToString());
-            var project = JsonSerializer.Deserialize<ProjectPayload>(response.Content!);
-            Assert.IsType<ProjectPayload>(project);
-        }
+//         [Then(@"the response should have a status code of ""(.*)"" and the new project should be added to the database and the response should contain the details of the newly created project")]
+//         public void Thentheresponseshouldhaveastatuscodeofandthenewprojectshouldbeaddedtothedatabaseandtheresponseshouldcontainthedetailsofthenewlycreatedproject(string statusCode)
+//         {
+//             RestResponse response = (RestResponse)_scenarioContext["Response"];
+//             Assert.True(response.IsSuccessful);
+//             Assert.Equal(statusCode, response.StatusCode.ToString());
+//             var project = JsonSerializer.Deserialize<ProjectModel>(response.Content!);
+//             Assert.IsType<ProjectModel>(project);
+//         }
 
-        [When(@"the user sends a POST request to the API endpoint with a JSON or XML payload that is missing required fields")]
-        public void WhentheusersendsaPOSTrequesttotheAPIendpointwithaJSONorXMLpayloadthatismissingrequiredfields()
-        {
-            ProjectPayload body = new ProjectPayload(
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
-            _scenarioContext["Response"] = Client.Post<ProjectPayload>(url, body);
-        }
+//         [When(@"the user sends a POST request to the API endpoint with a JSON or XML payload that is missing required fields")]
+//         public void WhentheusersendsaPOSTrequesttotheAPIendpointwithaJSONorXMLpayloadthatismissingrequiredfields()
+//         {
+//             ProjectModel body = new ProjectModel(
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null
+//             );
+//             _scenarioContext["Response"] = Client.Post<ProjectModel>(url, body);
+//         }
 
-        [Then(@"the response should have a status code of ""(.*)"" and a error message indicating missing fields")]
-        public void Thentheresponseshouldhaveastatuscodeofandaerrormessageindicatingmissingfields(string statusCode)
-        {
-            RestResponse response = (RestResponse)_scenarioContext["Response"];
+//         [Then(@"the response should have a status code of ""(.*)"" and a error message indicating missing fields")]
+//         public void Thentheresponseshouldhaveastatuscodeofandaerrormessageindicatingmissingfields(string statusCode)
+//         {
+//             RestResponse response = (RestResponse)_scenarioContext["Response"];
 
-            Assert.True(response.IsSuccessful);
-            Assert.Equal(statusCode, response.StatusCode.ToString());
-            var res = JsonSerializer.Deserialize<ErrorResponseModel>(response.Content!);
-            Assert.IsType<ErrorResponseModel>(res);
-        }
-    }
-}
+//             Assert.True(response.IsSuccessful);
+//             Assert.Equal(statusCode, response.StatusCode.ToString());
+//             var res = JsonSerializer.Deserialize<ErrorModel>(response.Content!);
+//             Assert.IsType<ErrorModel>(res);
+//         }
+//     }
+// }

--- a/3.Tests/API/StepDefinitions/Project/UpdateByIdStepDefinition.cs
+++ b/3.Tests/API/StepDefinitions/Project/UpdateByIdStepDefinition.cs
@@ -1,83 +1,83 @@
-﻿using System.Text.Json;
-using RestSharp;
-using TechTalk.SpecFlow;
-using Todoly.Tests.API.Steps.Commons;
-using Todoly.Views.Models;
+﻿// using System.Text.Json;
+// using RestSharp;
+// using TechTalk.SpecFlow;
+// using Todoly.Tests.API.Steps.Commons;
+// using Todoly.Views.Models;
 
-namespace Todoly.Tests.API.Steps.Project.Project.Update
-{
-    [Binding]
-    [Scope(Feature = "Update a Project by ID")]
-    public class StepDefinitionsUpdate : CommonSteps
-    {
-        private readonly ScenarioContext _scenarioContext;
-        private string ApiUrl = "";
+// namespace Todoly.Tests.API.Steps.Project.Project.Update
+// {
+//     [Binding]
+//     [Scope(Feature = "Update a Project by ID")]
+//     public class StepDefinitionsUpdate : CommonSteps
+//     {
+//         private readonly ScenarioContext _scenarioContext;
+//         private string ApiUrl = "";
 
-        public StepDefinitionsUpdate(ScenarioContext scenarioContext) : base(scenarioContext)
-        {
-            _scenarioContext = scenarioContext;
-        }
+//         public StepDefinitionsUpdate(ScenarioContext scenarioContext) : base(scenarioContext)
+//         {
+//             _scenarioContext = scenarioContext;
+//         }
 
-        [When(@"the user has a valid project ""(.*)"" and submits a PUT request to the API endpoint")]
-        public void WhentheuserhasavalidprojectIDandsubmitsaPUTrequesttotheAPIendpoint(int expectedId)
-        {
-            ApiUrl = $"projects/{expectedId}.json";
-            var username = _scenarioContext["username"].ToString();
-            var password = _scenarioContext["password"].ToString();
-            Client.AddDefaultHeader("Accept", "*/*");
-            Client.AddAuthenticator(username: username!, password: password!);
+//         [When(@"the user has a valid project ""(.*)"" and submits a PUT request to the API endpoint")]
+//         public void WhentheuserhasavalidprojectIDandsubmitsaPUTrequesttotheAPIendpoint(int expectedId)
+//         {
+//             ApiUrl = $"projects/{expectedId}.json";
+//             var username = _scenarioContext["username"].ToString();
+//             var password = _scenarioContext["password"].ToString();
+//             Client.AddDefaultHeader("Accept", "*/*");
+//             Client.AddAuthenticator(username: username!, password: password!);
 
-            ProjectPayload body = new ProjectPayload(
-                id: expectedId,
-                content: "New Content Name",
-                itemOrder: 4
-            );
+//             ProjectModel body = new ProjectModel(
+//                 id: expectedId,
+//                 content: "New Content Name",
+//                 itemOrder: 4
+//             );
 
-            _scenarioContext["Response"] = Client.Put<ProjectPayload>(ApiUrl, body);
-        }
+//             _scenarioContext["Response"] = Client.Put<ProjectModel>(ApiUrl, body);
+//         }
 
-        [Then(
-            "the API should return a (.*) status code and the project should be updated in the database"
-        )]
-        public void Thenincludestheupdatedprojectcontentitemscounticonitemtypeparentidcollapsedanditemorderintherequestbody(string expectedCode)
-        {
-            RestResponse response = (RestResponse)_scenarioContext["Response"];
-            Assert.True(response.IsSuccessful);
-            Assert.Equal(expectedCode, response.StatusCode.ToString());
-            var project = JsonSerializer.Deserialize<ProjectPayload>(response.Content!);
-            Assert.IsType<ProjectPayload>(project);
+//         [Then(
+//             "the API should return a (.*) status code and the project should be updated in the database"
+//         )]
+//         public void Thenincludestheupdatedprojectcontentitemscounticonitemtypeparentidcollapsedanditemorderintherequestbody(string expectedCode)
+//         {
+//             RestResponse response = (RestResponse)_scenarioContext["Response"];
+//             Assert.True(response.IsSuccessful);
+//             Assert.Equal(expectedCode, response.StatusCode.ToString());
+//             var project = JsonSerializer.Deserialize<ProjectModel>(response.Content!);
+//             Assert.IsType<ProjectModel>(project);
 
-        }
+//         }
 
-        [When(
-            @"the user has a invalid project ""(.*)"" and submits a PUT request to the API endpoint"
-        )]
-        public void ThentheuserhasainvalidprojectIDandsubmitsaPUTrequesttotheAPIendpoint(int expectedID)
-        {
-            ApiUrl = $"projects/{expectedID}.json";
-            var username = _scenarioContext["username"].ToString();
-            var password = _scenarioContext["password"].ToString();
-            Client.AddDefaultHeader("Accept", "*/*");
-            Client.AddAuthenticator(username: username!, password: password!);
+//         [When(
+//             @"the user has a invalid project ""(.*)"" and submits a PUT request to the API endpoint"
+//         )]
+//         public void ThentheuserhasainvalidprojectIDandsubmitsaPUTrequesttotheAPIendpoint(int expectedID)
+//         {
+//             ApiUrl = $"projects/{expectedID}.json";
+//             var username = _scenarioContext["username"].ToString();
+//             var password = _scenarioContext["password"].ToString();
+//             Client.AddDefaultHeader("Accept", "*/*");
+//             Client.AddAuthenticator(username: username!, password: password!);
 
-            ProjectPayload body = new ProjectPayload(
-                id: expectedID,
-                content: "New Content",
-                itemOrder: 4
-            );
-            _scenarioContext["Response"] = Client.Put<ProjectPayload>(ApiUrl, body);
-        }
+//             ProjectModel body = new ProjectModel(
+//                 id: expectedID,
+//                 content: "New Content",
+//                 itemOrder: 4
+//             );
+//             _scenarioContext["Response"] = Client.Put<ProjectModel>(ApiUrl, body);
+//         }
 
-        [Then(
-            @"the API should return a ""(.*)"" status code and an no JSON file"
-        )]
-        public void ThentheAPIshouldreturnaOKstatuscodeandanemptyJSON(string expectedCode)
-        {
-            RestResponse response = (RestResponse)_scenarioContext["Response"];
+//         [Then(
+//             @"the API should return a ""(.*)"" status code and an no JSON file"
+//         )]
+//         public void ThentheAPIshouldreturnaOKstatuscodeandanemptyJSON(string expectedCode)
+//         {
+//             RestResponse response = (RestResponse)_scenarioContext["Response"];
 
-            Assert.True(response.IsSuccessful);
-            Assert.Equal(expectedCode, response.StatusCode.ToString());
-            Assert.Empty(response.Content!);
-        }
-    }
-}
+//             Assert.True(response.IsSuccessful);
+//             Assert.Equal(expectedCode, response.StatusCode.ToString());
+//             Assert.Empty(response.Content!);
+//         }
+//     }
+// }

--- a/3.Tests/API/StepDefinitions/User/DeleteStepDefinitions.cs
+++ b/3.Tests/API/StepDefinitions/User/DeleteStepDefinitions.cs
@@ -1,67 +1,67 @@
-﻿using System.Text.Json;
-using RestSharp;
-using TechTalk.SpecFlow;
-using Todoly.Tests.API.Steps.Commons;
-using Todoly.Views.Models;
+﻿// using System.Text.Json;
+// using RestSharp;
+// using TechTalk.SpecFlow;
+// using Todoly.Tests.API.Steps.Commons;
+// using Todoly.Views.Models;
 
-namespace Todoly.Tests.API.Steps.User
-{
-    [Binding]
-    [Scope(Feature = "User Deletion")]
-    public class DeleteStepDefinitions : CommonSteps
-    {
-        private readonly ScenarioContext _scenarioContext;
+// namespace Todoly.Tests.API.Steps.User
+// {
+//     [Binding]
+//     [Scope(Feature = "User Deletion")]
+//     public class DeleteStepDefinitions : CommonSteps
+//     {
+//         private readonly ScenarioContext _scenarioContext;
 
-        public DeleteStepDefinitions(ScenarioContext scenarioContext) : base(scenarioContext)
-        {
-            _scenarioContext = scenarioContext;
-        }
+//         public DeleteStepDefinitions(ScenarioContext scenarioContext) : base(scenarioContext)
+//         {
+//             _scenarioContext = scenarioContext;
+//         }
 
-        [When(@"the user submits a POST request to ""(.*)"" with a valid JSON body")]
-        public void WhentheusersubmitsaPOSTrequesttowithavalidJSONbody(string url, string body)
-        {
-            UserPayload? user = Newtonsoft.Json.JsonConvert.DeserializeObject<UserPayload>(body);
-            _scenarioContext["Response"] = Client.Post<UserPayload>(url, user);
-        }
+//         [When(@"the user submits a POST request to ""(.*)"" with a valid JSON body")]
+//         public void WhentheusersubmitsaPOSTrequesttowithavalidJSONbody(string url, string body)
+//         {
+//             UserModel? user = Newtonsoft.Json.JsonConvert.DeserializeObject<UserModel>(body);
+//             _scenarioContext["Response"] = Client.Post<UserModel>(url, user);
+//         }
 
-        [When(@"the user submits a DELETE request to ""(.*)"" to delete his account")]
-        public void GiventheusersubmitsaDELETErequesttotodeletehisaccount(string url)
-        {
-            Client.Authenticate("deleteUser@email.com", "password");
-            Client.Delete(url);
-        }
+//         [When(@"the user submits a DELETE request to ""(.*)"" to delete his account")]
+//         public void GiventheusersubmitsaDELETErequesttotodeletehisaccount(string url)
+//         {
+//             Client.Authenticate("deleteUser@email.com", "password");
+//             Client.Delete(url);
+//         }
 
-        [Then(@"the API should return a ""(.*)"" status code and the deleted user information in JSON format")]
-        public void ThentheAPIshouldreturnastatuscodeandthedeleteduserinformationinJSONformat(string statusCode)
-        {
-            RestResponse response = (RestResponse)_scenarioContext["Response"];
+//         [Then(@"the API should return a ""(.*)"" status code and the deleted user information in JSON format")]
+//         public void ThentheAPIshouldreturnastatuscodeandthedeleteduserinformationinJSONformat(string statusCode)
+//         {
+//             RestResponse response = (RestResponse)_scenarioContext["Response"];
 
-            Assert.True(response.IsSuccessful);
-            Assert.Equal(statusCode, response.StatusCode.ToString());
-            var user = JsonSerializer.Deserialize<UserPayload>(response.Content!);
-            Assert.IsType<UserPayload>(user);
-            Assert.Equal("deleteUser@email.com", user.Email);
-        }
+//             Assert.True(response.IsSuccessful);
+//             Assert.Equal(statusCode, response.StatusCode.ToString());
+//             var user = JsonSerializer.Deserialize<UserModel>(response.Content!);
+//             Assert.IsType<UserModel>(user);
+//             Assert.Equal("deleteUser@email.com", user.Email);
+//         }
 
-        [When(@"the user submits a DELETE request to ""(.*)""")]
-        public void WhentheusersubmitsaDELETErequestto(string url)
-        {
-            Client.AddDefaultHeader("Authorization", _scenarioContext["Authorization"].ToString()!);
-            Client.AddDefaultHeader("Accept", "*/*");
-            _scenarioContext["Response"] = Client.Delete(url);
-        }
+//         [When(@"the user submits a DELETE request to ""(.*)""")]
+//         public void WhentheusersubmitsaDELETErequestto(string url)
+//         {
+//             Client.AddDefaultHeader("Authorization", _scenarioContext["Authorization"].ToString()!);
+//             Client.AddDefaultHeader("Accept", "*/*");
+//             _scenarioContext["Response"] = Client.Delete(url);
+//         }
 
-        [Then(@"the API should return a ""(.*)"" response with a (.*) status code and a ""(.*)"" error message indicating that the user is not authorized to access the resource.")]
-        public void ThentheAPIshouldreturnaresponsewithastatuscodeandaerrormessageindicatingthattheuserisnotauthorizedtoaccesstheresource(string response, int statusCode, string message)
-        {
-            RestResponse res = (RestResponse)_scenarioContext["Response"];
+//         [Then(@"the API should return a ""(.*)"" response with a (.*) status code and a ""(.*)"" error message indicating that the user is not authorized to access the resource.")]
+//         public void ThentheAPIshouldreturnaresponsewithastatuscodeandaerrormessageindicatingthattheuserisnotauthorizedtoaccesstheresource(string response, int statusCode, string message)
+//         {
+//             RestResponse res = (RestResponse)_scenarioContext["Response"];
 
-            Assert.True(res.IsSuccessful);
-            Assert.Equal(response, res.StatusCode.ToString());
-            var error = JsonSerializer.Deserialize<ErrorResponseModel>(res.Content!);
-            Assert.IsType<ErrorResponseModel>(error);
-            Assert.Equal(message, error!.ErrorMessage);
-            Assert.Equal(statusCode, error!.ErrorCode);
-        }
-    }
-}
+//             Assert.True(res.IsSuccessful);
+//             Assert.Equal(response, res.StatusCode.ToString());
+//             var error = JsonSerializer.Deserialize<ErrorModel>(res.Content!);
+//             Assert.IsType<ErrorModel>(error);
+//             Assert.Equal(message, error!.ErrorMessage);
+//             Assert.Equal(statusCode, error!.ErrorCode);
+//         }
+//     }
+// }

--- a/3.Tests/API/StepDefinitions/User/GetStepDefinitions.cs
+++ b/3.Tests/API/StepDefinitions/User/GetStepDefinitions.cs
@@ -7,11 +7,10 @@ using Todoly.Views.Models;
 namespace Todoly.Tests.API.Steps.User
 {
     [Binding]
-    [Scope(Feature = "Retrieve an existing user")]
+    [Scope(Feature = "Retrieve user information")]
     public class GetStepDefinitions : CommonSteps
     {
         private readonly ScenarioContext _scenarioContext;
-        // private readonly string url = "user.json";
 
         public GetStepDefinitions(ScenarioContext scenarioContext) : base(scenarioContext)
         {
@@ -19,61 +18,21 @@ namespace Todoly.Tests.API.Steps.User
         }
 
         [When(@"the user submits a GET request to ""(.*)""")]
-        public void WhentheusersubmitsaGETrequestto(string url)
+        public void WhentheusersubmitsaGETrequestto(string endpoint)
         {
-            Client.AddDefaultHeader("Authorization", _scenarioContext["Authorization"].ToString()!);
-            Client.AddDefaultHeader("Accept", "*/*");
-
-            _scenarioContext["Response"] = Client.Get(url);
+            _scenarioContext["Response"] = Client.DoRequest(Method.Get, endpoint, null);
         }
 
-        [Then(@"the API should return a ""(.*)"" status code and the requested user information in JSON body format")]
-        public void ThentheAPIshouldreturnastatuscodeandtherequesteduserinformationinJSONbodyformat(string statusCode, string body)
+        [Then(@"the API should return a ""(.*)"" response with the requested user information")]
+        public void ThentheAPIshouldreturnastatuscode(string response, string body)
         {
+            RestResponse res = (RestResponse)_scenarioContext["Response"];
+            Assert.True(res.IsSuccessful);
+            Assert.Equal(response, res.StatusCode.ToString());
+            var user = JsonSerializer.Deserialize<UserModel>(res.Content!);
 
-            RestResponse response = (RestResponse)_scenarioContext["Response"];
-
-            Assert.True(response.IsSuccessful);
-            Assert.Equal(statusCode, response.StatusCode.ToString());
-
-            var user = JsonSerializer.Deserialize<UserPayload>(response.Content!);
-            Assert.IsType<UserPayload>(user);
+            Assert.IsType<UserModel>(user);
             Assert.Contains(user.Email!, body);
-        }
-
-        [When(@"the user submits a GET request to ""(.*)"" with an ""(.*)"" invalid user email")]
-        public void WhentheusersubmitsaGETrequesttowithaninvaliduseremail(string url, string email)
-        {
-            Client.Authenticate(email, "password");
-            _scenarioContext["Response"] = Client.Get(url);
-        }
-
-        [Then(@"the API should return a ""(.*)"" response with a (.*) status code and a ""(.*)"" error message indicating that the user was not found")]
-        public void ThentheAPIshouldreturnaresponsewithastatuscodeandaerrormessageindicatingthattheuserwasnotfound(string response, int statusCode, string message)
-        {
-            RestResponse res = (RestResponse)_scenarioContext["Response"];
-
-            Assert.True(res.IsSuccessful);
-            Assert.Equal(response, res.StatusCode.ToString());
-
-            var error = JsonSerializer.Deserialize<ErrorResponseModel>(res.Content!);
-            Assert.IsType<ErrorResponseModel>(error);
-            Assert.Equal(message, error!.ErrorMessage);
-            Assert.Equal(statusCode, error!.ErrorCode);
-        }
-
-        [Then(@"the API should return a ""(.*)"" response with a (.*) status code and a ""(.*)"" error message indicating that the user is not authorized to access the resource.")]
-        public void ThentheAPIshouldreturnaresponsewithastatuscodeandaerrormessageindicatingthattheuserisnotauthorizedtoaccesstheresource(string response, int statusCode, string message)
-        {
-            RestResponse res = (RestResponse)_scenarioContext["Response"];
-
-            Assert.True(res.IsSuccessful);
-            Assert.Equal(response, res.StatusCode.ToString());
-
-            var error = JsonSerializer.Deserialize<ErrorResponseModel>(res.Content!);
-            Assert.IsType<ErrorResponseModel>(error);
-            Assert.Equal(message, error!.ErrorMessage);
-            Assert.Equal(statusCode, error!.ErrorCode);
         }
     }
 }

--- a/3.Tests/API/StepDefinitions/User/PutStepDefinitions.cs
+++ b/3.Tests/API/StepDefinitions/User/PutStepDefinitions.cs
@@ -1,99 +1,99 @@
-﻿using System.Text.Json;
-using RestSharp;
-using TechTalk.SpecFlow;
-using Todoly.Tests.API.Steps.Commons;
-using Todoly.Views.Models;
+﻿// using System.Text.Json;
+// using RestSharp;
+// using TechTalk.SpecFlow;
+// using Todoly.Tests.API.Steps.Commons;
+// using Todoly.Views.Models;
 
-namespace Todoly.Tests.API.Steps.User
-{
-    [Binding]
-    [Scope(Feature = "User Update")]
-    public class PutStepDefinitions : CommonSteps
-    {
-        private readonly ScenarioContext _scenarioContext;
+// namespace Todoly.Tests.API.Steps.User
+// {
+//     [Binding]
+//     [Scope(Feature = "User Update")]
+//     public class PutStepDefinitions : CommonSteps
+//     {
+//         private readonly ScenarioContext _scenarioContext;
 
-        public PutStepDefinitions(ScenarioContext scenarioContext) : base(scenarioContext)
-        {
-            _scenarioContext = scenarioContext;
-        }
+//         public PutStepDefinitions(ScenarioContext scenarioContext) : base(scenarioContext)
+//         {
+//             _scenarioContext = scenarioContext;
+//         }
 
-        [When(@"the user submits a PUT request to ""(.*)"" with a valid JSON body")]
-        public void WhentheusersubmitsaPUTrequesttowithavalidJSONbody(string url, string body)
-        {
-            Client.AddDefaultHeader("Authorization", _scenarioContext["Authorization"].ToString()!);
-            Client.AddDefaultHeader("Accept", "*/*");
+//         [When(@"the user submits a PUT request to ""(.*)"" with a valid JSON body")]
+//         public void WhentheusersubmitsaPUTrequesttowithavalidJSONbody(string url, string body)
+//         {
+//             Client.AddDefaultHeader("Authorization", _scenarioContext["Authorization"].ToString()!);
+//             Client.AddDefaultHeader("Accept", "*/*");
 
-            UserPayload? user = Newtonsoft.Json.JsonConvert.DeserializeObject<UserPayload>(body);
-            _scenarioContext["Response"] = Client.Put<UserPayload>(url, user);
-        }
+//             UserModel? user = Newtonsoft.Json.JsonConvert.DeserializeObject<UserModel>(body);
+//             _scenarioContext["Response"] = Client.Put<UserModel>(url, user);
+//         }
 
-        [Then(@"the API should return a ""(.*)"" status code and the updated user information in JSON format")]
-        public void ThentheAPIshouldreturnastatuscodeandtheupdateduserinformationinJSONformat(string statusCode)
-        {
-            RestResponse response = (RestResponse)_scenarioContext["Response"];
-            Assert.True(response.IsSuccessful);
-            Assert.Equal(statusCode, response.StatusCode.ToString());
-            var user = JsonSerializer.Deserialize<UserPayload>(response.Content!);
-            Assert.IsType<UserPayload>(user);
-            Assert.Equal("New Name", user.FullName);
-        }
+//         [Then(@"the API should return a ""(.*)"" status code and the updated user information in JSON format")]
+//         public void ThentheAPIshouldreturnastatuscodeandtheupdateduserinformationinJSONformat(string statusCode)
+//         {
+//             RestResponse response = (RestResponse)_scenarioContext["Response"];
+//             Assert.True(response.IsSuccessful);
+//             Assert.Equal(statusCode, response.StatusCode.ToString());
+//             var user = JsonSerializer.Deserialize<UserModel>(response.Content!);
+//             Assert.IsType<UserModel>(user);
+//             Assert.Equal("New Name", user.FullName);
+//         }
 
-        [When(@"the user submits a PUT request to ""(.*)"" with an invalid ""(.*)"" user email")]
-        public void WhentheusersubmitsaPUTrequesttowithaninvaliduseremail(string url, string email)
-        {
-            Client.AddDefaultHeader("Authorization", "Basic aW52YWxpZEBlbWFpbC5jb206UGFzc3dvcmQ=");
-            Client.AddDefaultHeader("Accept", "*/*");
+//         [When(@"the user submits a PUT request to ""(.*)"" with an invalid ""(.*)"" user email")]
+//         public void WhentheusersubmitsaPUTrequesttowithaninvaliduseremail(string url, string email)
+//         {
+//             Client.AddDefaultHeader("Authorization", "Basic aW52YWxpZEBlbWFpbC5jb206UGFzc3dvcmQ=");
+//             Client.AddDefaultHeader("Accept", "*/*");
 
-            UserPayload body = new UserPayload(
-                email,
-                "newPassword",
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            );
-            _scenarioContext["Response"] = Client.Put<UserPayload>(url, body);
-        }
+//             UserModel body = new UserModel(
+//                 email,
+//                 "newPassword",
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null,
+//                 null
+//             );
+//             _scenarioContext["Response"] = Client.Put<UserModel>(url, body);
+//         }
 
-        [Then(@"the API should return a ""(.*)"" response with a (.*) status code and a ""(.*)"" error message indicating that the user was not found")]
-        public void ThentheAPIshouldreturnaresponsewithastatuscodeandaerrormessageindicatingthattheuserwasnotfound(string response, int statusCode, string message)
-        {
-            RestResponse res = (RestResponse)_scenarioContext["Response"];
+//         [Then(@"the API should return a ""(.*)"" response with a (.*) status code and a ""(.*)"" error message indicating that the user was not found")]
+//         public void ThentheAPIshouldreturnaresponsewithastatuscodeandaerrormessageindicatingthattheuserwasnotfound(string response, int statusCode, string message)
+//         {
+//             RestResponse res = (RestResponse)_scenarioContext["Response"];
 
-            Assert.True(res.IsSuccessful);
-            Assert.Equal(response, res.StatusCode.ToString());
+//             Assert.True(res.IsSuccessful);
+//             Assert.Equal(response, res.StatusCode.ToString());
 
-            var error = JsonSerializer.Deserialize<ErrorResponseModel>(res.Content!);
-            Assert.IsType<ErrorResponseModel>(error);
-            Assert.Equal(message, error!.ErrorMessage);
-            Assert.Equal(statusCode, error!.ErrorCode);
-        }
+//             var error = JsonSerializer.Deserialize<ErrorModel>(res.Content!);
+//             Assert.IsType<ErrorModel>(error);
+//             Assert.Equal(message, error!.ErrorMessage);
+//             Assert.Equal(statusCode, error!.ErrorCode);
+//         }
 
-        [When(@"the user submits a PUT request to ""(.*)""")]
-        public void WhentheusersubmitsaPUTrequestto(string url)
-        {
-            _scenarioContext["Response"] = Client.Put<UserPayload>(url, body: null!);
-        }
+//         [When(@"the user submits a PUT request to ""(.*)""")]
+//         public void WhentheusersubmitsaPUTrequestto(string url)
+//         {
+//             _scenarioContext["Response"] = Client.Put<UserModel>(url, body: null!);
+//         }
 
-        [Then(@"the API should return a ""(.*)"" response with a (.*) status code and a ""(.*)"" error message indicating that the user is not authorized to access the resource.")]
-        public void ThentheAPIshouldreturnaresponsewithastatuscodeandaerrormessageindicatingthattheuserisnotauthorizedtoaccesstheresource(string response, int statusCode, string message)
-        {
-            RestResponse res = (RestResponse)_scenarioContext["Response"];
+//         [Then(@"the API should return a ""(.*)"" response with a (.*) status code and a ""(.*)"" error message indicating that the user is not authorized to access the resource.")]
+//         public void ThentheAPIshouldreturnaresponsewithastatuscodeandaerrormessageindicatingthattheuserisnotauthorizedtoaccesstheresource(string response, int statusCode, string message)
+//         {
+//             RestResponse res = (RestResponse)_scenarioContext["Response"];
 
-            Assert.True(res.IsSuccessful);
-            Assert.Equal(response, res.StatusCode.ToString());
+//             Assert.True(res.IsSuccessful);
+//             Assert.Equal(response, res.StatusCode.ToString());
 
-            var error = JsonSerializer.Deserialize<ErrorResponseModel>(res.Content!);
-            Assert.IsType<ErrorResponseModel>(error);
-            Assert.Equal(message, error!.ErrorMessage);
-            Assert.Equal(statusCode, error!.ErrorCode);
-        }
-    }
-}
+//             var error = JsonSerializer.Deserialize<ErrorModel>(res.Content!);
+//             Assert.IsType<ErrorModel>(error);
+//             Assert.Equal(message, error!.ErrorMessage);
+//             Assert.Equal(statusCode, error!.ErrorCode);
+//         }
+//     }
+// }

--- a/3.Tests/API/appsettings.json
+++ b/3.Tests/API/appsettings.json
@@ -1,0 +1,15 @@
+{
+  "api": {
+    "ApiHostUrl": "https://todo.ly/api/",
+    "ProjectUri": "projects.json",
+    "ItemUri": "items.json",
+    "UserUri": "user.json",
+    "CurrentProject": "CurrentProject"
+  },
+  "ui": {
+    "DriverImplicitTimeout": 15,
+    "DriverExplicitTimeout": 30,
+    "HostUrl": "https://todo.ly/",
+    "DriverType": "Chrome"
+  }
+}

--- a/3.Tests/UI/Hooks/ProjectHooks.cs
+++ b/3.Tests/UI/Hooks/ProjectHooks.cs
@@ -35,15 +35,16 @@ public class ProjectHooks
     {
         string payload = $"{{ \"Content\": \"{_projectName}\" }}";
 
-        _client.Authenticate(ConfigModel.TODO_LY_EMAIL, ConfigModel.TODO_LY_PASS);
+        _client.AddAuthenticator(ConfigModel.TODO_LY_EMAIL, ConfigModel.TODO_LY_PASS);
 
-        RestResponse response = _client.Post(_url, payload);
+        // RestResponse response = _client.Post(_url, payload);
+        RestResponse response = _client.DoRequest(Method.Post, _url, payload);
         if (!response.IsSuccessful)
         {
             throw new Exception("Error: Bad Request");
         }
 
-        ProjectPayload? projectContent = JsonSerializer.Deserialize<ProjectPayload>(
+        ProjectModel? projectContent = JsonSerializer.Deserialize<ProjectModel>(
             response.Content!
         );
         if (projectContent!.Content != _projectName)


### PR DESCRIPTION
- Added ```DoRequest()``` method to APIRestHelper and removed Get, Post, Put and Delete methods.
- Refactor all API gherkin files to have the same conventions and common steps
- Change Models classes names
- Added common steps for authentication, API response and error message response
- Refactor ```GetStepDefinition``` and ```PostStepDefinition``` user tests classes to work with new implementation
- Commented rest of steps classes and gherkin files until refactor with new implementation

Now you will be able to create the hooks for the UI project using only the ```DoRequest()``` method from the APIRestHelper. In this PR I'm implementing it with the ProjectHooks that Adriel created and it works.