### PR TITLE
Fixed warning

### DIFF
--- a/3.Tests/UI/StepDefinitions/Item/AddAboveBelowStepDefinition.cs
+++ b/3.Tests/UI/StepDefinitions/Item/AddAboveBelowStepDefinition.cs
@@ -15,7 +15,6 @@ namespace MyNamespace
     {
         private readonly HomePage _homePage;
         private readonly ScenarioContext _scenarioContext;
-        private readonly string _itemName = "";
         private string _newItem = "";
 
         public AddBelowStepDefinitions(ScenarioContext scenarioContext) : base(scenarioContext)


### PR DESCRIPTION
Fixed warning on line 18 in `3.Tests/UI/StepDefinitions/Item/AddAboveBelowStepDefinition.cs`.
`The field 'AddBelowStepDefinitions._itemName' is assigned but its value is never used`

fixes #119 