### PR TITLE
Refactored viewNames conventions on gherkin files and common steps

### DIFF
--- a/3.Tests/UI/Features/Item/AddAboveBelow.feature
+++ b/3.Tests/UI/Features/Item/AddAboveBelow.feature
@@ -7,9 +7,9 @@ Feature: Add Above Below Item
 
     @smoke @create.project.Kids @create.item.Lunch @create.item.Sleep @delete.projects
     Scenario Outline: Successfully addition of an item above or below an existing item
-        When the user clicks on 'Project Button' <Kids> on 'Project Component'
-        And the user hovers on "Get Item" <Lunch> on 'Items Component'
-        And the user clicks on "Item Contextmenu" <Lunch> on "Add item <position>" option on "Items Component"
+        When the user clicks on 'Project Button' <Kids> at 'Project Component'
+        And the user hovers on "Get Item" <Lunch> at 'Items Component'
+        And the user clicks on "Item Contextmenu" <Lunch> on "Add item <position>" option at "Items Component"
         Then the user enters "<new_item>" and saves it
         And the "<new_item>" should be added <position> the "Lunch"
 

--- a/3.Tests/UI/Features/Item/CheckItem.feature
+++ b/3.Tests/UI/Features/Item/CheckItem.feature
@@ -7,6 +7,6 @@ Feature: Checking a Todo Item
 
     @Smoke @create.project.NewProject @create.item.NewItem
     Scenario: Checking an Item in a Project successfully
-        When the user clicks on 'Project Button' <NewProject> on 'Project Component'
+        When the user clicks on 'Project Button' <NewProject> at 'Project Component'
         When the user checks the item
         Then the item should be listed in the Done Items

--- a/3.Tests/UI/Features/Item/Create.feature
+++ b/3.Tests/UI/Features/Item/Create.feature
@@ -7,7 +7,7 @@ Feature: Create an Item in a Project
 
     @create.project.NewProject
     Scenario: Create an Item Successfully
-        When the user clicks on 'Project Button' <NewProject> on 'Project Component'
+        When the user clicks on 'Project Button' <NewProject> at 'Project Component'
         When enters the item "new katas for monday" on Add New Todo input
         Then the item should be displayed in the project list
 

--- a/3.Tests/UI/Features/Item/Delete.feature
+++ b/3.Tests/UI/Features/Item/Delete.feature
@@ -6,9 +6,9 @@ Feature: Item Deletion
 
     @Smoke @Regression @create.project.Shopping @create.item.Bananas @UI_Delete_Item
     Scenario: Delete a pending item succesfully
-        When the user clicks on 'Project Button' <Shopping> on 'Project Component'
-        And the user hovers on "Get Item" <Bananas> on 'Items Component'
-        And the user clicks on "Item Contextmenu" <Bananas> on "Delete" option on "Items Component"
+        When the user clicks on 'Project Button' <Shopping> at 'Project Component'
+        And the user hovers on "Get Item" <Bananas> at 'Items Component'
+        And the user clicks on "Item Contextmenu" <Bananas> on "Delete" option at "Items Component"
         Then the item should be removed from the section
 
 # Scenario: Delete all done items succesfully

--- a/3.Tests/UI/Features/Item/DueDate.feature
+++ b/3.Tests/UI/Features/Item/DueDate.feature
@@ -6,21 +6,21 @@ Feature: Item Due Date
 
     @Smoke @Regression @create.project.Calendar @create.item.NewItem @Due_Date_Item
     Scenario: Update the Due Date of an item succesfully
-        When the user clicks on 'Project Button' <Calendar> on 'Project Component'
+        When the user clicks on 'Project Button' <Calendar> at 'Project Component'
         And the user clicks on the Set Due Date option
         And inputs "1 Mar 12:00 AM" as due date
         Then the item should be displayed with the "1 Mar 12:00 AM" date-tag
 
     @Smoke @Regression @create.project.PastNotes @create.item.Apples @Due_Date_Item
     Scenario: Update the Due Date of an item succesfully to a date in the past
-        When the user clicks on 'Project Button' <PastNotes> on 'Project Component'
+        When the user clicks on 'Project Button' <PastNotes> at 'Project Component'
         And the user clicks on the Set Due Date option
         And inputs "20 Jun 2020 02:00 AM" as due date
         Then the item should be displayed as overdue
 
     @Smoke @Regression @create.project.NotImportant @delete.projects @create.item.Clean @Due_Date_Item
     Scenario Outline: Postpone the Due Date of an item succesfully
-        When the user clicks on 'Project Button' <NotImportant> on 'Project Component'
+        When the user clicks on 'Project Button' <NotImportant> at 'Project Component'
         And the user clicks on the Set Due Date option
         And inputs "20 Jun 12:00 PM" as due date
         And clicks on Postpone <Postpone>

--- a/3.Tests/UI/Features/Item/Priority.feature
+++ b/3.Tests/UI/Features/Item/Priority.feature
@@ -6,9 +6,9 @@ Feature: Item Priority
 
     @Smoke @Regression @create.project.Kids @create.item.EatLunch @delete.projects @UI_Priority_Item
     Scenario Outline: Delete a pending item succesfully
-        When the user clicks on 'Project Button' <Kids> on 'Project Component'
-        And the user hovers on "Get Item" <EatLunch> on 'Items Component'
-        And the user clicks on "Item Contextmenu" <EatLunch> on "<Priority>" option on "Items Component"
+        When the user clicks on 'Project Button' <Kids> at 'Project Component'
+        And the user hovers on "Get Item" <EatLunch> at 'Items Component'
+        And the user clicks on "Item Contextmenu" <EatLunch> on "<Priority>" option at "Items Component"
         Then the <EatLunch> color should be <Color>
 
         Examples:

--- a/3.Tests/UI/Features/Item/Update.feature
+++ b/3.Tests/UI/Features/Item/Update.feature
@@ -6,7 +6,7 @@ Feature: Item Update
 
     @Smoke @Regression @create.project.Exercise @create.item.Math @UI_Update_Item
     Scenario: Update a name of an item succesfully
-        When the user clicks on 'Project Button' <Exercise> on 'Project Component'
+        When the user clicks on 'Project Button' <Exercise> at 'Project Component'
         And the user clicks on the item
         And inputs a new item name and press enter
         Then the item should be displayed with the new name

--- a/3.Tests/UI/Features/Project/Create.feature
+++ b/3.Tests/UI/Features/Project/Create.feature
@@ -6,7 +6,7 @@
 
     @Smoke @Regression
     Scenario: Create a new project
-        When the user clicks on 'Add New Project' on 'Home Page'
+        When the user clicks on 'Add New Project' at 'Home Page'
             And types "My New Project" on 'New Project Name'
             And clicks on 'Add New Project Name'
-        Then the 'Project Button' <My New Project> should be displayed on 'Project Component'
+        Then the 'Project Button' <My New Project> should be displayed at 'Project Component'

--- a/3.Tests/UI/Features/Project/UpdateName.feature
+++ b/3.Tests/UI/Features/Project/UpdateName.feature
@@ -6,7 +6,7 @@ Feature: Project Update
 
     @Regression @create.project.MyProject
     Scenario: Edit a project
-        When the user opens the context menu on <MyProject> on 'Project Component'
+        When the user opens the context menu on <MyProject> at 'Project Component'
             And clicks on 'Edit Project Button' <MyProject>
             And types "My New Project Name" on 'Edit Project Input'
             And clicks on 'Save Edit Project'

--- a/3.Tests/UI/Features/RecycleBin/DeleteAll.feature
+++ b/3.Tests/UI/Features/RecycleBin/DeleteAll.feature
@@ -5,9 +5,9 @@ Feature: Empty recycle bin
 
     @Regression
     Scenario: Empty the recycle bin succesfully
-        When the user hovers on 'Recycle Bin Div' on 'Home Page'
+        When the user hovers on 'Recycle Bin Div' at 'Home Page'
         And clicks on 'Recycle Bin Dropdown'
         And clicks on 'Empty Recycle Bin'
         Then the main title text is "Recycle Bin"
-        And the snack bar message is 'Recycle Bin has been Emptied.' on 'Home Page'
+        And the snack bar message is 'Recycle Bin has been Emptied.' at 'Home Page'
         And the recycle bin should should be empty

--- a/3.Tests/UI/Features/Settings/Account/View.feature
+++ b/3.Tests/UI/Features/Settings/Account/View.feature
@@ -5,6 +5,6 @@ Feature: Settings account view
 
     @Regression
     Scenario: View account settings succesfully
-        When the user clicks on 'Settings' on 'Home Page'
+        When the user clicks on 'Settings' at 'Home Page'
         And clicks on 'Account'
-        Then the 'Delete Account' should be displayed on 'Home Page'
+        Then the 'Delete Account' should be displayed at 'Home Page'

--- a/3.Tests/UI/Features/Settings/Profile/UpdateEmail.feature
+++ b/3.Tests/UI/Features/Settings/Profile/UpdateEmail.feature
@@ -6,15 +6,15 @@ Feature: Email update
 
     @Smoke @Acceptance @recover.email
     Scenario: Update email succesfully
-        When the user clicks on 'Settings' on 'Home Page'
+        When the user clicks on 'Settings' at 'Home Page'
             And types "testjg@email.com" on 'Email' on 'Profile Page'
             And clicks on 'Ok'
         Then an alert should appear with the message "Email Address has changed, please relogin." 
         When the user accepts the alert
-            And clicks on 'Login' on 'Login Page'
+            And clicks on 'Login' at 'Login Page'
             And introduces his credentials
             And clicks on 'Confirm Login'
-        Then the 'Logout' should be displayed on 'Home Page'
+        Then the 'Logout' should be displayed at 'Home Page'
 
     # @Negative
     # Scenario: Fail to update email with empty input
@@ -29,4 +29,3 @@ Feature: Email update
     #     And clicks on the OK button
     #     Then an alert should appear with the message "Email Address already exists" 
     #         And an accept button is displayed
-

--- a/3.Tests/UI/Features/Settings/Profile/UpdateFullName.feature
+++ b/3.Tests/UI/Features/Settings/Profile/UpdateFullName.feature
@@ -6,11 +6,11 @@ Feature: Full name update
 
     @Smoke @Regression @restore.default.fullname
     Scenario: Update full name succesfully
-        When the user clicks on 'Settings' on 'Home Page'
+        When the user clicks on 'Settings' at 'Home Page'
             And types "New Name" on 'FullName' on 'Profile Page'
             And clicks on 'Ok'
         Then the 'NonDisplayedClose' should not be displayed
-        When the user clicks on 'Settings' on 'Home Page'
+        When the user clicks on 'Settings' at 'Home Page'
         Then the 'FullName' value is updated with 'New Name' on 'Profile Page'
 
     # @Negative

--- a/3.Tests/UI/Features/Settings/Profile/UpdatePassword.feature
+++ b/3.Tests/UI/Features/Settings/Profile/UpdatePassword.feature
@@ -6,7 +6,7 @@ Feature: Password update
 
     @Smoke @Acceptance @recover.password
     Scenario: Update password succesfully
-        When the user clicks on 'Settings' on 'Home Page'
+        When the user clicks on 'Settings' at 'Home Page'
             And types "Password Credential" on 'Old Password' on 'Profile Page'
             And types "New Password" on 'New Password'
             And clicks on 'Ok'
@@ -17,4 +17,3 @@ Feature: Password update
     #     And clicks on the OK button
     #     Then an alert should appear with the message "Invalid Password"
     #         And an accept button is displayed
-

--- a/3.Tests/UI/Features/Settings/Profile/UpdateTimeZone.feature
+++ b/3.Tests/UI/Features/Settings/Profile/UpdateTimeZone.feature
@@ -4,11 +4,10 @@ Feature: Time Zone update
     @Acceptance @restore.default.timezone
     Scenario: Update time zone succesfully
         Given the user is logged in
-        When the user clicks on 'Settings' on 'Home Page'
+        When the user clicks on 'Settings' at 'Home Page'
             And clicks on 'Time Zone' on 'Profile Page'
             And clicks on 'Hawaiian Time'
             And clicks on 'Ok'
         Then the 'NonDisplayedClose' should not be displayed
-        When the user clicks on 'Settings' on 'Home Page'
+        When the user clicks on 'Settings' at 'Home Page'
             And the 'Hawaiian Time' is selected on 'Profile Page'
-

--- a/3.Tests/UI/Features/Settings/Profile/View.feature
+++ b/3.Tests/UI/Features/Settings/Profile/View.feature
@@ -4,10 +4,9 @@ Feature: Profile settings view
     @Smoke @Regression
     Scenario: View profile settings succesfully
         Given the user is logged in
-        When the user clicks on 'Settings' on 'Home Page'
+        When the user clicks on 'Settings' at 'Home Page'
         Then the 'Profile Settings' should be displayed on 'Profile Page'
             And the 'FullName' should be displayed
             And the 'Email' should be displayed
             And the 'Old Password' should be displayed
             And the 'New Password' should be displayed
-

--- a/3.Tests/UI/Features/User/Login.feature
+++ b/3.Tests/UI/Features/User/Login.feature
@@ -4,7 +4,7 @@ Feature: User Login
     @Smoke
     Scenario: Login into the site succesfully
     Given the user navigates to the URL
-    When the user clicks on 'Login' on 'Login Page'
+    When the user clicks on 'Login' at 'Login Page'
         And introduces his credentials
         And clicks on 'Confirm Login'
-        Then the user should be able to see the 'Logout' button on 'Home Page'
+        Then the user should be able to see the 'Logout' button at 'Home Page'

--- a/3.Tests/UI/Features/User/Logout.feature
+++ b/3.Tests/UI/Features/User/Logout.feature
@@ -6,5 +6,5 @@ Feature: User Logout
 
     @Smoke
     Scenario: Logout off the site succesfully
-        When the user clicks on 'Logout' on 'Home Page'
+        When the user clicks on 'Logout' at 'Home Page'
         Then the user should be logged out from the site

--- a/3.Tests/UI/StepDefinitions/CommonStepDefinition.cs
+++ b/3.Tests/UI/StepDefinitions/CommonStepDefinition.cs
@@ -46,7 +46,7 @@ public class CommonSteps
         _loginPage.LoginIntoApplication();
     }
 
-    [When(@"(?:the user )?clicks on '([a-zA-Z ]+)'(?: on '([a-zA-Z ]+)')?$")]
+    [When(@"(?:the user )?clicks on '([a-zA-Z ]+)'(?: at '([a-zA-Z ]+)')?$")]
     public void Click(string elementName, string viewName)
     {
         if (viewName != null)
@@ -57,7 +57,7 @@ public class CommonSteps
         UIElementFactory.GetElement(elementName, CurrentView).Click();
     }
 
-    [When(@"(?:the user )?clicks on '([a-zA-Z ]+)' <([a-zA-Z ]+)>(?: on '([a-zA-Z ]+)')?$")]
+    [When(@"(?:the user )?clicks on '([a-zA-Z ]+)' <([a-zA-Z ]+)>(?: at '([a-zA-Z ]+)')?$")]
     public void Click(string elementName, string locatorArgument, string viewName)
     {
         if (viewName != null)
@@ -68,7 +68,7 @@ public class CommonSteps
         UIElementFactory.GetElement(elementName, CurrentView, locatorArgument).Click();
     }
 
-    [When(@"(?:the user )?types ""(.*)"" on '([a-zA-Z ]+)'(?: on '([a-zA-Z ]+)')?$")]
+    [When(@"(?:the user )?types ""(.*)"" on '([a-zA-Z ]+)'(?: at '([a-zA-Z ]+)')?$")]
     public void Type(string input, string elementName, string viewName)
     {
         if (viewName != null)
@@ -95,7 +95,7 @@ public class CommonSteps
         }
     }
 
-    [When(@"(?:the user )?opens the context menu on <([a-zA-Z ]+)>(?: on '([a-zA-Z ]+)')?$")]
+    [When(@"(?:the user )?opens the context menu on <([a-zA-Z ]+)>(?: at '([a-zA-Z ]+)')?$")]
     public void OpenContextMenu(string locatorArgument, string viewName)
     {
         if (viewName != null)
@@ -111,7 +111,7 @@ public class CommonSteps
         UIElementFactory.GetElement("Project Context Button", CurrentView, locatorArgument).Click();
     }
 
-    [Then(@"the '(.*)' should (not )?be displayed(?: on '([a-zA-Z ]+)')?$")]
+    [Then(@"the '(.*)' should (not )?be displayed(?: at '([a-zA-Z ]+)')?$")]
     public void ValidateDisplay(string elementName, string display, string viewName)
     {
         if (viewName != null)
@@ -131,7 +131,7 @@ public class CommonSteps
         }
     }
 
-    [Then(@"the '(.*)' <(.*)> should (not )?be displayed(?: on '([a-zA-Z ]+)')?$")]
+    [Then(@"the '(.*)' <(.*)> should (not )?be displayed(?: at '([a-zA-Z ]+)')?$")]
     public void ValidateDisplay(
         string elementName,
         string locatorArgument,
@@ -162,7 +162,7 @@ public class CommonSteps
         }
     }
 
-    [When(@"(?:the user )?hovers on '([a-zA-Z ]+)'(?: on '([a-zA-Z ]+)')?$")]
+    [When(@"(?:the user )?hovers on '([a-zA-Z ]+)'(?: at '([a-zA-Z ]+)')?$")]
     public void Hover(string elementName, string viewName)
     {
         if (viewName != null)
@@ -173,7 +173,7 @@ public class CommonSteps
         WebActions.HoverElement(UIElementFactory.GetElement(elementName, CurrentView).WebElement);
     }
 
-    [When(@"(?:the user )?hovers on ""([\w ]+)""(?: <([\w ]+)>)?(?: on '([\w ]+)')?$")]
+    [When(@"(?:the user )?hovers on ""([\w ]+)""(?: <([\w ]+)>)?(?: at '([\w ]+)')?$")]
     public void HoverItemName(string elementName, string itemName, string viewName)
     {
         if (viewName != null)
@@ -187,7 +187,7 @@ public class CommonSteps
     }
 
     [When(
-        @"(?:the user )?clicks on [\x22']([\w ]+)[\x22'](?: <([\w ]+)>)?(?: on [\x22']([\w ]+)[\x22'])? option on [\x22']([\w ]+)[\x22']$"
+        @"(?:the user )?clicks on [\x22']([\w ]+)[\x22'](?: <([\w ]+)>)?(?: on [\x22']([\w ]+)[\x22'])? option at [\x22']([\w ]+)[\x22']$"
     )]
     public void ClickContextOption(
         string elementName,

--- a/3.Tests/UI/StepDefinitions/User/LoginStepDefinition.cs
+++ b/3.Tests/UI/StepDefinitions/User/LoginStepDefinition.cs
@@ -23,11 +23,10 @@ public class LoginStepDefinitions : CommonSteps
         GenericWebDriver.Instance.Navigate().GoToUrl(ConfigModel.HostUrl);
     }
 
-    [Then(@"the user should be able to see the '(.*)' button on '(.*)'")]
+    [Then(@"the user should be able to see the '(.*)' button at '(.*)'")]
     public void ThenTheUserShouldBeAbleToSeeTheMainPage(string elementName, string viewName)
     {
         Assert.True(UIElementFactory.GetElement(elementName, viewName).WebElement.Displayed);
         Assert.That(GenericWebDriver.Instance.Title, Is.EqualTo("Todo.ly"));
     }
 }
-


### PR DESCRIPTION
On Gherkin file:
<i>Before</i>
`When the user clicks on 'Add New Project' on 'Home Page'`
`Then the 'Project Button' <My New Project> should be displayed on 'Project Component'`

<i>Now</i>
`When the user clicks on 'Add New Project' at 'Home Page'`
`Then the 'Project Button' <My New Project> should be displayed at 'Project Component'`

resolves #124